### PR TITLE
test: CXTB-320 automate senior ignores provider call

### DIFF
--- a/tests/cases/seniors_app/case_seniors_app_prompts.yaml
+++ b/tests/cases/seniors_app/case_seniors_app_prompts.yaml
@@ -412,3 +412,67 @@ TestSeniorAppIgnoreCarePartnerCall:
       Strategy: class_chain
       Id: $PAGE.seniors_app_call.video_button$
       Time: 10
+
+# CXTB-57: Verify Ignore Call for Provider on Never Alone Seniors app.
+TestSeniorAppIgnoreProviderCall:
+  Environment: Settings
+  Precases:
+    - LoginNeverAloneHelper
+  Aftercases:
+    - TerminateApp
+  Roles:
+    - Role: localiOS
+      App: NeverAlone
+    - Role: desktopChrome
+      App: desktop
+  Actions:
+  # Call participant(Senior) logged in as a Provider.
+    - Type: case
+      Value: ProviderCallParticipant
+  # Device begins ringing and automatically displays "Incoming Call" modal.
+    - Type: wait_for
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_incoming_call.incoming_call_header$
+    - Type: return_element_attribute
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_incoming_call.incoming_call_header$
+      Attribute: label
+      ResultVar: HEADER_TITLE
+    - Type: assert
+      Asserts:
+        - Type: eq
+          Var: HEADER_TITLE
+          Value: Incoming Call...
+  # Verify that it shows who is calling and their details, giving you the option to answer or ignore the call.
+    - Type: wait_for
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_incoming_call.called_name$
+    - Type: return_element_attribute
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_incoming_call.called_name$
+      Attribute: label
+      ResultVar: CALLER_VALUE
+    - Type: assert
+      Asserts:
+        - Type: eq
+          Var: CALLER_VALUE
+          Value: Dr. $AND_CLI_provider_user1_name$ $AND_CLI_provider_user1_lastname$
+    - Type: wait_for
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_incoming_call.answer_call_button$
+    - Type: wait_for
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_incoming_call.ignore_call_button$
+  # Click the "Ignore Call" button.
+    - Type: click
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_incoming_call.ignore_call_button$
+  # Verify that the device returns you to the screen without entering the call.
+    - Type: wait_not_visible
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_incoming_call.ignore_call_button$
+      Time: 10
+    - Type: wait_not_visible
+      Strategy: class_chain
+      Id: $PAGE.seniors_app_call.video_button$
+      Time: 10


### PR DESCRIPTION
Automated test case:
https://digitalscientists.atlassian.net/browse/CXTB-320

- Added test.

Proof of Successful run:
<img width="1251" alt="image" src="https://user-images.githubusercontent.com/118279681/228953722-a82b8541-73e7-4e43-9e91-0cc7ed64cca2.png">
