### PR TITLE
CXTB-394 Maintenance After Release Part1

### DIFF
--- a/tests/cases/care_partner_platform/case_care_platform_home.yaml
+++ b/tests/cases/care_partner_platform/case_care_platform_home.yaml
@@ -104,6 +104,8 @@ TestHomePage:
 #CXTB-223: Validating changes of status (Not in Call)
 TestStatusDropdown_NotInCall:
   Environment: Settings 
+  Precases:
+    - CarePartnerCleanCallQueueAndHangedCalls
   Roles:
     - Role: desktopChrome
       App: "desktop"

--- a/tests/cases/care_partner_platform/case_care_platform_participants.yaml
+++ b/tests/cases/care_partner_platform/case_care_platform_participants.yaml
@@ -246,11 +246,6 @@ TestParticipantCallHistory:
       Asserts:
         - Type: contain
           Var: DETAILS_CONTENT
-          Value: 'Partner'
-    - Type: assert
-      Asserts:
-        - Type: contain
-          Var: DETAILS_CONTENT
           Value: 'Notes'
 
 #CXTB-105 Click and View Participant Record from Listing

--- a/tests/cases/care_partner_platform/case_care_platform_participants.yaml
+++ b/tests/cases/care_partner_platform/case_care_platform_participants.yaml
@@ -35,6 +35,9 @@ TestCreateFollowUpTicket:
       Strategy: xpath
       Id: $PAGE.care_platform_participant_details.ticket_subject_input$
       Value: Automated test
+    - Type: scroll_to
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_details.ticket_kind_label$
     - Type: click
       Strategy: xpath
       Id: $PAGE.care_platform_participant_details.ticket_kind_input$
@@ -559,7 +562,7 @@ TestCarePartnerParticipantReview:
     - Type: scroll_to
       Role: desktopChrome
       Strategy: xpath
-      Id: $PAGE.care_platform_participant_details.specialist_button$
+      Id: $PAGE.care_platform_participant_details.specialists_block$
   #Check Call History tab
     - Type: click
       Role: desktopChrome

--- a/tests/cases/helpers/case_helpers_care_platform.yaml
+++ b/tests/cases/helpers/case_helpers_care_platform.yaml
@@ -660,12 +660,12 @@ AnswerCallAndRescheduleForOneHourLater:
     - Type: send_keys
       Role: desktopChrome
       Strategy: xpath
-      Id: $PAGE.providers_call_queue_page.subject_input$
+      Id: $PAGE.providers_call_handling_page.subject_input$
       Value: Automation Post call survey data
     - Type: send_keys
       Role: desktopChrome
       Strategy: xpath
-      Id: $PAGE.providers_call_queue_page.details_textarea$
+      Id: $PAGE.providers_call_handling_page.details_textarea$
       Value: Automation Post call survey data   
     - Type: wait_for_property
       Role: desktopChrome
@@ -847,12 +847,12 @@ AnswerPastCallAndRescheduleForOneHourLater:
     - Type: send_keys
       Role: desktopChrome
       Strategy: xpath
-      Id: $PAGE.providers_call_queue_page.subject_input$
+      Id: $PAGE.providers_call_handling_page.subject_input$
       Value: Automation Post call survey data
     - Type: send_keys
       Role: desktopChrome
       Strategy: xpath
-      Id: $PAGE.providers_call_queue_page.details_textarea$
+      Id: $PAGE.providers_call_handling_page.details_textarea$
       Value: Automation Post call survey data   
     - Type: wait_for_property
       Role: desktopChrome
@@ -1288,12 +1288,12 @@ PostCallSurveyCarePartner:
     - Type: send_keys
       Role: desktopChrome
       Strategy: xpath
-      Id: $PAGE.providers_call_queue_page.subject_input$
+      Id: $PAGE.providers_call_handling_page.subject_input$
       Value: Missed Call Subject Automation
     - Type: send_keys
       Role: desktopChrome
       Strategy: xpath
-      Id: $PAGE.providers_call_queue_page.details_textarea$
+      Id: $PAGE.providers_call_handling_page.details_textarea$
       Value: Automation Tear Down post call survey    
     - Type: wait_for_property
       Role: desktopChrome
@@ -1338,10 +1338,10 @@ PostCallSurveyCarePartner:
       Role: desktopChrome
       Strategy: xpath
       Id: $PAGE.care_platform_call_portal.submit_and_exit_session_button$
-    # - Type: wait_for
-    #   Role: desktopChrome
-    #   Strategy: xpath
-    #   Id: $PAGE.care_platform_notifications.call_completed_notification$
+    - Type: wait_for
+      Role: desktopChrome
+      Strategy: xpath
+      Id: $PAGE.care_platform_notifications.call_completed_notification$
     - Type: wait_for
       Role: desktopChrome
       Strategy: xpath

--- a/tests/page_objects/care_platform_page.yaml
+++ b/tests/page_objects/care_platform_page.yaml
@@ -88,7 +88,7 @@ care_platform_participant:
   first_senior_lastname: //*[@id='containerElement']/div[@role='button'][1]//strong
   call_portal_btn: //button[text()='Call Portal']
   search_button: //button[span[@class='icon-search']]
-  search_input: //input[contains(@placeholder,'Search by participant name')]
+  search_input: //input[@id='searchText']
   clear_search_button: //button[contains(@class,'button-circle')]
   status_dropdown_button: //button[contains(@class,'queue-filter-dropdown-toggle')]
   status_dropdown_options: //div[contains(@class, 'queue-filter-dropdown')]  

--- a/tests/page_objects/care_platform_page.yaml
+++ b/tests/page_objects/care_platform_page.yaml
@@ -84,8 +84,8 @@ care_platform_participant:
   first_darkened_letter_button: //button[@class='alphabet-letter'][not(@disabled)][1]
   selected_darkened_letter_button: //button[contains(@class,'is-selected')]
   senior_complete_name: //div[starts-with(@class, 'SearchableListTemplate_record')]//div[contains(text(),'$AND_CLI_senior_user1_name$')][strong[contains(text(),'$AND_CLI_senior_user1_lastname$')]]
-  senior_1_row: //*[@id='containerElement']/table[1]/tbody/tr[1]
-  first_senior_lastname: //*[@id='containerElement']/table[1]/tbody/tr[1]//strong
+  senior_1_row: //*[@id='containerElement']/div[@role='button'][1]
+  first_senior_lastname: //*[@id='containerElement']/div[@role='button'][1]//strong
   call_portal_btn: //button[text()='Call Portal']
   search_button: //button[span[@class='icon-search']]
   search_input: //input[contains(@placeholder,'Search by participant name')]
@@ -108,6 +108,7 @@ care_platform_participant_details:
   primary_care_physician: //strong[text()='Primary Care Physician']
   pharmacy_button: //button[text()='Pharmacy']
   preferred_lab_button: //button[text()='Preferred Lab']
+  specialists_block: //*[@id='providers']//*[contains(text(),'Specialists')][@class='is-block']
   specialist_button: //button[text()='Specialist']
   call_history_tab_button: //nav/button[contains(text(),'Call History')]
   first_call_history_row: //div[@tab-title='Call History']//div[contains(@class,'accordion-item call')][1]
@@ -115,6 +116,7 @@ care_platform_participant_details:
   follow_up_tab_button: //nav/button[contains(text(),'Follow-up Tickets')]
   create_ticket_button: //div[@tab-title='Follow-up Tickets']//button[contains(text(),'Create Ticket')]
   ticket_subject_input: //*[@id='subject']
+  ticket_kind_label: //label[@for='kind']
   ticket_kind_input: //*[@id='kind']
   kind_medical_appointment_option: //*[@id='kind']/optgroup[@label='Medical']/option[@value='med_appointment']
   ticket_assigned_input: //*[@id='assignedAdminId']

--- a/tests/page_objects/providers_care_platform_page.yaml
+++ b/tests/page_objects/providers_care_platform_page.yaml
@@ -110,12 +110,12 @@ providers_follow_up_call_details_page:
 providers_employees_page:
   employees_label: //h3[text()='Employees']
   search_button: //button[span[@class='icon-search']]
-  search_input: //input[contains(@placeholder,'Search by employee name')]
+  search_input: //input[@id='searchText']
   clear_search_button: //button[contains(@class,'button-circle')]
   first_darkened_letter_button: //button[@class='alphabet-letter'][not(@disabled)][1]
   selected_darkened_letter_button: //button[contains(@class,'is-selected')]
-  first_employee_in_list_strong: //*[@id='containerElement']/table[1]/tbody/tr[1]//strong
-  first_employee: //*[@id='containerElement']/table[1]/tbody/tr[1]
+  first_employee_in_list_strong: //*[@id='containerElement']/div[@role='button'][1]//strong
+  first_employee: //*[@id='containerElement']/div[@role='button'][1]
   employee_dob_label: //strong[@class='color-green-300' and text()='DOB']
   employee_dob_content: //div[@class='flex-col flex-col-auto']/time
   employee_contact_label: //strong[@class='color-green-300' and text()='Contact']


### PR DESCRIPTION
-Redefine page objects to match new ones.
-Added cleaner precases to test that needs to start with a clean slate.

-Test: TestAccessEmployeesDirectoryAndFilter
![image](https://user-images.githubusercontent.com/118225389/236230343-ad7cf6a8-1fa5-466f-a1b9-972fa669d852.png)

-Test: TestStatusDropdown_NotInCall
![image](https://user-images.githubusercontent.com/118225389/236236039-a7fc9500-0f94-44d1-9c3b-a9bb32133d53.png)

-Test: TestCreateFollowUpTicket
![image](https://user-images.githubusercontent.com/118225389/236236604-2a2528ce-c662-4f9f-8ffe-9445bf69082a.png)

-Test: TestParticipantDirectoryFilter
![image](https://user-images.githubusercontent.com/118225389/236237039-88af1093-024c-4602-bf1d-5a808e082f3f.png)

-Test: TestParticipantCallHistory
![image](https://user-images.githubusercontent.com/118225389/236241192-35deebf7-5663-4fe2-96a1-2c1922c7ef59.png)

-Test: TestParticipantRecordListing
![image](https://user-images.githubusercontent.com/118225389/236241660-0af56e95-bbec-459e-aa82-e80fa9518eab.png)

-Test: TestCarePartnerParticipantReview
![image](https://user-images.githubusercontent.com/118225389/236242602-d6449daf-e77e-4ffa-a3c7-870c28e358c0.png)

-Test: TestCarePartnerAnswerAndComplete
![image](https://user-images.githubusercontent.com/118225389/236244123-a3a782ac-a474-46f2-9bdf-84ca1c8f5071.png)
