### PR TITLE
CXTB-379 Assert the removal of the CCA status label

### DIFF
--- a/tests/cases/skilled_nurse_facility/case_skilled_nurse_facility_requests.yaml
+++ b/tests/cases/skilled_nurse_facility/case_skilled_nurse_facility_requests.yaml
@@ -80,6 +80,27 @@ TestSNFNewRequestFormBehavior:
     - Type: click
       Strategy: class_chain
       Id: $PAGE.snf_new_request_form.patient_name_select$
+    #Check there's no CCA status label on patient
+    - Type: return_element_attribute
+      Strategy: class_chain
+      Id: $PAGE.snf_new_request_form.first_patient_select_option$
+      Attribute: label
+      ResultVar: FIRST_PATIENT_LABEL
+    - Type: assert
+      Asserts:
+        - Type: contain
+          Var: FIRST_PATIENT_LABEL
+          Value: "MRN"
+    - Type: assert
+      Asserts:
+        - Type: contain
+          Var: FIRST_PATIENT_LABEL
+          Value: "Birthdate"
+    - Type: assert
+      Asserts:
+        - Type: n_contain
+          Var: FIRST_PATIENT_LABEL
+          Value: "CCA"
     - Type: click
       Strategy: class_chain
       Id: $PAGE.snf_new_request_form.first_patient_select_option$


### PR DESCRIPTION
Checking there's no CCA status in the patient dropdown
![image](https://github.com/neveralone-chs-org/TestRay/assets/118225389/a7afe764-94ea-44dd-ad6d-8cee11d0f913)
