### PR TITLE
CXTB-419 Update test TestProviderStatusNotOnActiveCall

### DIFF
--- a/tests/cases/providers_care_platform/case_providers_home.yaml
+++ b/tests/cases/providers_care_platform/case_providers_home.yaml
@@ -109,9 +109,11 @@ TestProviderHomePageListingView:
         Value: "Follow-up"
         raise: true
 
-# CXTB-231 Status Drop-down Options - Not on Active Call
+# CXTB-104 Provider's Status - Not on Active Call
 TestProviderStatusNotOnActiveCall:
-  Environment: Settings  
+  Environment: Settings
+  Precases:
+    - ProviderCleanBeforeTest
   Roles:
     - Role: desktopChrome
       App: desktop
@@ -119,90 +121,10 @@ TestProviderStatusNotOnActiveCall:
       # Login to the Care Platform app with Providers account
     - Type: case
       Value: ProvidersCarePlatformLogin
-      # Status
-    - Type: click
-      Strategy: xpath
-      Id : $PAGE.care_platform_header.user_dropdown_button$
+      # Status should be available after login
     - Type: wait_for
-      Strategy: xpath
-      Id: $PAGE.care_platform_header.status_menu_header$
-    - Type: wait_for
-      Strategy: xpath
-      Id: $PAGE.care_platform_header.status_available_button$
-      # Changing status to away
-    - Type: click
-      Strategy: xpath
-      Id: $PAGE.care_platform_header.status_away_button$
-      # Navigate to Facilities
-    - Type: click
-      Strategy: xpath
-      Id: $PAGE.providers_home_page.facilities_navigation$
-      # Checking indicator is set to Away status
-    - Type: get_attribute
       Strategy: xpath
       Id: $PAGE.care_platform_header.status_indicator$
-      Greps:
-        - var: STATUS_VAR
-          attr: class
-          condition: nempty
-          match: "(.*)has-status(.*)"
-    - Type: assert
-      Asserts:
-        - Type: contain
-          Var: STATUS_VAR
-          Value: "is-empty"
-      # Trying to change status to In Session (shouldn't let you do it manually)
-    - Type: click
-      Strategy: xpath
-      Id : $PAGE.care_platform_header.user_dropdown_button$
-    - Type: wait_for
-      Strategy: xpath
-      Id: $PAGE.care_platform_header.status_insession_button$
-    - Type: click_js
-      Strategy: xpath
-      Id: $PAGE.care_platform_header.status_insession_button$
-      # Navigate to Employees
-    - Type: click
-      Strategy: xpath
-      Id : $PAGE.providers_home_page.employees_navigation$
-      # Verifying the status indicator didn't change to In Session
-    - Type: get_attribute
-      Strategy: xpath
-      Id: $PAGE.care_platform_header.status_indicator$
-      Greps:
-        - var: STATUS_VAR
-          attr: class
-          condition: nempty
-          match: "(.*)has-status(.*)"
-    - Type: assert
-      Asserts:
-        - Type: contain
-          Var: STATUS_VAR
-          Value: "is-empty"
-      # Changing status back to available
-    - Type: click
-      Strategy: xpath
-      Id : $PAGE.care_platform_header.user_dropdown_button$
-    - Type: wait_for
-      Strategy: xpath
-      Id: $PAGE.care_platform_header.status_menu_header$
-    - Type: click
-      Strategy: xpath
-      Id: $PAGE.care_platform_header.status_available_button$
-    - Type: click
-      Strategy: xpath
-      Id : $PAGE.providers_home_page.employees_navigation$
-    - Type: get_text
-      Strategy: xpath
-      Id : $PAGE.care_platform.page_title$
-      Greps:
-        - var: HOME_TITLE
-          match: "Employees*"
-      Asserts:
-        - Type: eq
-          Var: HOME_TITLE
-          Value: "Employees"
-      # Checking the status indicator correspond to Available
     - Type: get_attribute
       Strategy: xpath
       Id: $PAGE.care_platform_header.status_indicator$
@@ -216,6 +138,83 @@ TestProviderStatusNotOnActiveCall:
         - Type: contain
           Var: STATUS_VAR
           Value: "is-green"
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.care_platform_header.user_dropdown_button$
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.providers_user_dropdown_menu.user_status_available$
+      #Shift status "ON SHIFT"
+    - Type: get_text
+      Strategy: xpath
+      Id: $PAGE.providers_user_dropdown_menu.user_shift_toggle_label$
+      Greps:
+        - var: SHIFT_VAR
+          condition: nempty
+          match: "(.*)"
+    - Type: assert
+      Asserts:
+        - Type: contain
+          Var: SHIFT_VAR
+          Value: "On"
+      #Change shift status to off
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.providers_user_dropdown_menu.user_shift_toggle_checkbox$
+    - Type: sleep
+      Time: 2
+    - Type: get_text
+      Strategy: xpath
+      Id: $PAGE.providers_user_dropdown_menu.user_shift_toggle_label$
+      Greps:
+        - var: SHIFT_VAR
+          condition: nempty
+          match: "(.*)"
+    - Type: assert
+      Asserts:
+        - Type: contain
+          Var: SHIFT_VAR
+          Value: "Off"
+      #Change back to available
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.providers_user_dropdown_menu.user_shift_toggle_checkbox$
+    - Type: sleep
+      Time: 2
+      #Log out and stay on shift, to check if the status is Idle
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.providers_home_page.home_button$
+      # Calling Logout case.
+    - Type: set_env_var
+      Value: "Stay On Shift"
+      Var: LOGOUT_OPTION
+    - Type: case
+      Value: CarePlatformLogout
+      # Log in with the second user.
+    - Type: case
+      Value: ProviderLoginSecondaryUser
+    # Click on the users dropdown.
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.care_platform_header.headset_dropdown_button$
+    # Verify that the first user has stayed on shift, and Idle
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.providers_user_dropdown_menu.user_list_item_provider1$
+    - Type: get_attribute
+      Strategy: xpath
+      Id: $PAGE.providers_user_dropdown_menu.user_list_item_provider1$
+      Greps:
+        - var: STATUS_PROVIDER1
+          attr: innerHTML
+          condition: nempty
+          match: "(.*)"
+    - Type: assert
+      Asserts:
+        - Type: contain
+          Var: STATUS_PROVIDER1
+          Value: "Idle"
 
 # Physical Device only.
 # CXTB-133: Verify that Providers answer SNF call and completes session.

--- a/tests/page_objects/providers_care_platform_page.yaml
+++ b/tests/page_objects/providers_care_platform_page.yaml
@@ -26,6 +26,12 @@ providers_home_page:
   call_history_navigation: //header//a[text()='Call History']
   call_history_title_tab: //nav/button[text()='Call History']
 
+providers_user_dropdown_menu:
+  user_status_available: //header//nav[@class='user-dropdown-menu']//span[text()='available']
+  user_shift_toggle_label: //nav[@class='user-dropdown-menu']//div[contains(@class,'radio-toggle-label')]
+  user_shift_toggle_checkbox: //nav[@class='user-dropdown-menu']//label[contains(@class,'radio-toggle-button')]
+  user_list_item_provider1: //div[contains(text(),'On Shift')]//following-sibling::div[not(contains(@class,'is-offline'))]//div[@class='users-dropdown-name'][contains(text(),'$AND_CLI_provider_user1_name$')][contains(.,'$AND_CLI_provider_user1_lastname$')][contains(.,'Provider')]
+
 providers_account_modal:
   credentials_navigation_tab: //*[@id='modals']//nav/button[text()='Credentials']
   credentials_content: //*[@id='modals']//div[@class='tabs-content' and @tab-title='Credentials']


### PR DESCRIPTION
-Added page objects
-Remade test TestProviderStatusNotOnActiveCall to reflect new behavior:
login - available
Answer call - in session (doesn't go in this test)
Complete session - available (doesn't go in this test)
Time out or log out stay on shift - idle

Config file needs the provider1 first name and last name, to work

![image](https://github.com/neveralone-chs-org/TestRay/assets/118225389/09305a47-1e61-435d-b03f-1ae567681aef)