### PR TITLE
test: CXTB-431 Negative Toast With No Message If Save Changes for Participant with Duplicated Email

### DIFF
--- a/tests/cases/onboarders_care_platform/case_onboarders_care_platform_account.yaml
+++ b/tests/cases/onboarders_care_platform/case_onboarders_care_platform_account.yaml
@@ -508,3 +508,104 @@ TestOnboarderClickAndViewFacilitiesDevice:
       - Type: contain
         Var: STATUS_CLASS 
         Value: 'active'
+
+# CXTB-457: Negative Toast With No Message If Save Changes for Participant with Duplicated Email
+TestOnboarderNoNegativeToastIfParticipantIsSavedWithDuplicatedEmail:
+    Environment: Settings 
+    Roles:
+    - Role: desktopChrome
+      App: "desktop"
+    Actions:
+  # Log in Care Platform as an Onboarder.
+    - Type: case
+      Value: OnboarderCarePartnerLogin
+  # Navigate to the Participants Page.
+    - Type: case
+      Value: CarePartnerNavigateToParticipants
+  # Click on the desired participant.
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant.senior_complete_name$
+  # Click on "Edit Info".
+    - Type: sleep
+      Time: 2
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.onboarders_participant_details_pane.edit_info$
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.onboarders_participant_details_pane.edit_info$
+  # User is redirected to the "Edit Info" page.
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.onboarders_edit_participant_records.email_address_input$
+  # Copy the email and navigate back to the Participants page.
+    - Type: return_element_attribute
+      Strategy: xpath
+      Id: $PAGE.onboarders_edit_participant_records.email_address_input$
+      Attribute: value
+      ResultVar: COPIED_EMAIL_ADDRESS
+    - Type: case
+      Value: CarePartnerNavigateToParticipants
+  # Select another participant and click on the "Edit Info" button.
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant.senior2_complete_name$
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant.senior2_complete_name$
+    - Type: sleep
+      Time: 2
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.onboarders_participant_details_pane.edit_info$
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.onboarders_participant_details_pane.edit_info$
+  # User is redirected to the "Edit Info" page.
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.onboarders_edit_participant_records.email_address_input$
+    - Type: return_element_attribute
+      Strategy: xpath
+      Id: $PAGE.onboarders_edit_participant_records.email_address_input$
+      Attribute: value
+      ResultVar: ORIGINAL_EMAIL_ADDRESS
+  # Enter the copied email address on the Demographics page of the Participant and then click on Save Changes.
+    - Type: clear_field_by_backspace
+      Strategy: xpath
+      Id: $PAGE.onboarders_edit_participant_records.email_address_input$
+    - Type: send_keys
+      Strategy: xpath
+      Id: $PAGE.onboarders_edit_participant_records.email_address_input$
+      Value: $AND_CLI_COPIED_EMAIL_ADDRESS$
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.onboarders_edit_participant_records.save_changes_button$
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.onboarders_edit_participant_records.save_changes_button$
+  # User must validate that gets a toast notification saying that changes were saved.
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.onboarders_notifications.participant_changes_saved_notification$
+    - Type: wait_not_visible
+      Strategy: xpath
+      Id: $PAGE.onboarders_notifications.participant_changes_saved_notification$
+  # Changed the email back to the way it was.
+    - Type: clear_field_by_backspace
+      Strategy: xpath
+      Id: $PAGE.onboarders_edit_participant_records.email_address_input$
+    - Type: send_keys
+      Strategy: xpath
+      Id: $PAGE.onboarders_edit_participant_records.email_address_input$
+      Value: $AND_CLI_ORIGINAL_EMAIL_ADDRESS$
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.onboarders_edit_participant_records.save_changes_button$
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.onboarders_edit_participant_records.save_changes_button$
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.onboarders_notifications.participant_changes_saved_notification$

--- a/tests/page_objects/care_platform_page.yaml
+++ b/tests/page_objects/care_platform_page.yaml
@@ -82,6 +82,7 @@ care_platform_participant:
   first_darkened_letter_button: //button[@class='alphabet-letter'][not(@disabled)][1]
   selected_darkened_letter_button: //button[contains(@class,'is-selected')]
   senior_complete_name: //div[starts-with(@class, 'ListRow_listRow')]//div[contains(text(),'$AND_CLI_senior_user1_name$')][strong[contains(text(),'$AND_CLI_senior_user1_lastname$')]]
+  senior2_complete_name: //div[starts-with(@class, 'ListRow_listRow')]//div[contains(text(),'$AND_CLI_senior_user2_name$')][strong[contains(text(),'$AND_CLI_senior_user2_lastname$')]]
   esidd_senior_complete_name: //div[starts-with(@class, 'ListRow_listRow')]//div[contains(text(),'$AND_CLI_idd_es_never_alone_user1_name$')][strong[contains(text(),'$AND_CLI_idd_es_never_alone_user1_lastname$')]]
   chidd_senior_complete_name: //div[starts-with(@class, 'ListRow_listRow')]//div[contains(text(),'$AND_CLI_idd_ch_never_alone_user2_name$')][strong[contains(text(),'$AND_CLI_idd_ch_never_alone_user2_lastname$')]]
   senior_1_row: //*[@id='containerElement']/div[@role='button'][1]

--- a/tests/page_objects/onboarders_care_platform_page.yaml
+++ b/tests/page_objects/onboarders_care_platform_page.yaml
@@ -6,6 +6,7 @@ onboarders_edit_participant_records:
   account_status_option_based_on_input: //select[@id='accountStatus']/option[@value='$AND_CLI_ACCOUNT_STATUS$']
   participant_suspended_status_option: //*[@id='accountStatus']/option[@value='suspended']
   participant_active_status_option: //*[@id='accountStatus']/option[@value='active']
+  email_address_input: //input[@id='emailAddress']
   save_changes_button: //button[text()='Save Changes']
 
 onboarders_notifications:


### PR DESCRIPTION
automated test case:
https://digitalscientists.atlassian.net/browse/CXTB-457

- added test.
- added objects.

**NOTE: Senior users must be populated on the config.yaml**
Proof of Successful run:
![image](https://github.com/neveralone-chs-org/TestRay/assets/118279681/bb0ff2f4-dd4c-4b80-a9bb-3153bd52f096)
