### PR TITLE
CHS-2534-CarePartner-Redirected-to-Home

### DIFF
--- a/tests/cases/admin_on_call_care_platform/case_admin_on_call_care_platform_user_actions.yaml
+++ b/tests/cases/admin_on_call_care_platform/case_admin_on_call_care_platform_user_actions.yaml
@@ -91,11 +91,18 @@ TestAdminOnCallRefreshUserAccountForCalling:
       Role: desktopChrome1
       Id: $PAGE.care_platform_call_portal.yes_refresh_dialog_button$
   # Care Partner check for notification and redirection home
-  #   Note: This part is not happening, waiting for further instructions.
     - Type: wait_not_visible
       Strategy: xpath
       Role: desktopChrome
       Id: $PAGE.care_platform_call_portal.end_call_button$
+    - Type: wait_for
+      Strategy: xpath
+      Role: desktopChrome
+      Id: $PAGE.care_platform.call_queue_title$
+    - Type: wait_for
+      Strategy: xpath
+      Role: desktopChrome
+      Id: $PAGE.care_platform_home.queue_header_columns$
   # Check on Senior that takes you to survey
     - Type: wait_for
       Strategy: class_chain

--- a/tests/page_objects/care_platform_page.yaml
+++ b/tests/page_objects/care_platform_page.yaml
@@ -33,6 +33,7 @@ care_platform_home:
   call_based_on_ch_idd_participant_name: //div[contains(@class, 'ListRow_listRow')]//strong[text() = '$AND_CLI_idd_ch_never_alone_user2_name$ $AND_CLI_idd_ch_never_alone_user2_lastname$']
   active_call_section: //div[contains(@class,'app-video app-video-fixed')] # doesn't matter if its expanded/collapsed
   call_queue_calls: //div[@id='containerElement']/div[starts-with(@class, 'ListRow_listRow') and not(contains(., 'Follow-up'))]
+  queue_header_columns: //div[contains(text(),'Type')]/following-sibling::div[contains(text(),'Participant')]/following-sibling::div[contains(text(),'Assigned')]
 
 care_platform_header:
   app_logo: //header//div[@class='app-header-small-logo']/img


### PR DESCRIPTION
-Adding step for redirection to Home, after refresh. Test: TestAdminOnCallRefreshUserAccountForCalling

![image](https://github.com/neveralone-chs-org/TestRay/assets/118225389/e80d8729-2549-44d8-8989-0e603cf6a827)