### PR TITLE
CXTB-649 Update Account Info Related Tests After Twilio Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Actions:
       Value: https://webcamtests.com/
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.webcamtest_page.check_webcam_link$
+      Id: $PAGE.webcamtest_page.check_webcam_link$
       Greps:
           - var: check_webcam_text
             match: "Check Webcam"

--- a/examples/tests/cases/case_av_example.yaml
+++ b/examples/tests/cases/case_av_example.yaml
@@ -38,7 +38,7 @@ TestBrowserChromeAV:
       Value: https://webcamtests.com/
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.webcamtest_page.check_webcam_link$
+      Id: $PAGE.webcamtest_page.check_webcam_link$
       Greps:
           - var: check_webcam_text
             match: "Check Webcam"

--- a/tests/cases/admin_on_call_care_platform/case_admin_on_call_care_platform_account.yaml
+++ b/tests/cases/admin_on_call_care_platform/case_admin_on_call_care_platform_account.yaml
@@ -64,7 +64,7 @@ TestAdminOnCallLogoutGoOffShift:
       Id: $PAGE.care_platform_header.offline_carepartner1_element$
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform_header.offline_carepartner1_element$
+      Id: $PAGE.care_platform_header.offline_carepartner1_element$
       Greps:
         - var: CARE_PARTNER_ELEMENT
           match: "(.*)"

--- a/tests/cases/admin_on_call_care_platform/case_admin_on_call_queue.yaml
+++ b/tests/cases/admin_on_call_care_platform/case_admin_on_call_queue.yaml
@@ -74,11 +74,11 @@ TestAdminOnCallShouldNotAnswerProviderCallAfterMedicalTransfer:
   # Telehealth request form window disappears.
     - Type: wait_not_visible
       Strategy: xpath
-      Id : $PAGE.care_platform_call_portal.telehealth_request_form_header$
+      Id: $PAGE.care_platform_call_portal.telehealth_request_form_header$
   # Verify "End Call" button has been replaced with "Leave Call" button.
     - Type: wait_for
       Strategy: xpath
-      Id : $PAGE.care_platform_call_portal.leave_call_btn$
+      Id: $PAGE.care_platform_call_portal.leave_call_btn$
   # Log in as a provider and join the call
     - Type: case
       Value: ProvidersCarePlatformLogin

--- a/tests/cases/care_partner_platform/case_care_platform_events.yaml
+++ b/tests/cases/care_partner_platform/case_care_platform_events.yaml
@@ -301,7 +301,7 @@ TestCarePartnerCreateEventForParticipant:
   # Telehealth request form window disappears. 
     - Type: wait_not_visible
       Strategy: xpath
-      Id : $PAGE.care_platform_call_portal.telehealth_request_form_header$
+      Id: $PAGE.care_platform_call_portal.telehealth_request_form_header$
   # Schedule listing is updated to include the event you’ve just created.
     - Type: wait_for
       Strategy: xpath

--- a/tests/cases/care_partner_platform/case_care_platform_home.yaml
+++ b/tests/cases/care_partner_platform/case_care_platform_home.yaml
@@ -18,7 +18,7 @@ TestCarePartnerHomePage:
   #Checking Home page and navigation
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform.page_title$
+      Id: $PAGE.care_platform.page_title$
       Greps:
         - var: HOME_TITLE
           match: "Care Partners"
@@ -30,13 +30,13 @@ TestCarePartnerHomePage:
           Value: "Care Partners"
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform.navigation_participant$
+      Id: $PAGE.care_platform.navigation_participant$
     - Type: wait_for
       Strategy: xpath
-      Id : $PAGE.care_platform.page_title$
+      Id: $PAGE.care_platform.page_title$
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform.page_title$
+      Id: $PAGE.care_platform.page_title$
       Greps:
         - var: HOME_TITLE
           match: "Participants"
@@ -57,7 +57,7 @@ TestCarePartnerHomePage:
   #Checking options in the user drop-down
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.user_dropdown_button$
+      Id: $PAGE.care_platform_header.user_dropdown_button$
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.care_platform_header.user_toggle_input$
@@ -93,7 +93,7 @@ TestCarePartnerStatusDropdown_NotInCall:
   #Status
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.user_dropdown_button$
+      Id: $PAGE.care_platform_header.user_dropdown_button$
   #Changing status to Off Shift
     - Type: wait_for
       Strategy: xpath
@@ -104,10 +104,10 @@ TestCarePartnerStatusDropdown_NotInCall:
   #Navigating to participants page
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform.navigation_participant$
+      Id: $PAGE.care_platform.navigation_participant$
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform.page_title$
+      Id: $PAGE.care_platform.page_title$
       Greps:
         - var: HOME_TITLE
           match: "Participants"
@@ -132,7 +132,7 @@ TestCarePartnerStatusDropdown_NotInCall:
   #Changing status back to available
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.user_dropdown_button$
+      Id: $PAGE.care_platform_header.user_dropdown_button$
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.care_platform_header.user_toggle_input$
@@ -182,11 +182,11 @@ TestCarePartnerAccountHelp:
   #Going to My Account
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.user_dropdown_button$
+      Id: $PAGE.care_platform_header.user_dropdown_button$
   #Going to Help
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.help_menu_button$
+      Id: $PAGE.care_platform_header.help_menu_button$
   #Verify the Help page is visible
     - Type: switch_window
       Value: 1
@@ -266,7 +266,7 @@ TestCarePartnerLogoutGoOffShift:
       Id: $PAGE.care_platform_header.offline_carepartner1_element$
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform_header.offline_carepartner1_element$
+      Id: $PAGE.care_platform_header.offline_carepartner1_element$
       Greps:
         - var: CARE_PARTNER_ELEMENT
           match: "(.*)"
@@ -340,7 +340,7 @@ TestCarePartnerAccessAndReviewTeamMembersAvailability:
   # Verify that the list shows care partner users and current statuses.
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform_header.users_dropdown_list$
+      Id: $PAGE.care_platform_header.users_dropdown_list$
       Greps:
       - var: USERS_LIST_TEXT
         match: '[\s\S]*' # using single quotes due to YAML issues with regex and double quotes.

--- a/tests/cases/care_partner_platform/case_care_platform_participants.yaml
+++ b/tests/cases/care_partner_platform/case_care_platform_participants.yaml
@@ -13,7 +13,7 @@ TestCarePartnerCreateFollowUpTicket:
   #Go to participants
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform.navigation_participant$
+      Id: $PAGE.care_platform.navigation_participant$
   #Select first participant in the list
     - Type: wait_for
       Strategy: xpath
@@ -1037,11 +1037,11 @@ TestCarePartnerAnswerCallFromQueueAndCompleteMedicalTransfer:
   # Telehealth request form window disappears.
     - Type: wait_not_visible
       Strategy: xpath
-      Id : $PAGE.care_platform_call_portal.telehealth_request_form_header$
+      Id: $PAGE.care_platform_call_portal.telehealth_request_form_header$
   # Verify "End Call" button has been replaced with "Leave Call" button.
     - Type: wait_for
       Strategy: xpath
-      Id : $PAGE.care_platform_call_portal.leave_call_btn$
+      Id: $PAGE.care_platform_call_portal.leave_call_btn$
   # Log in as a provider
     - Type: case
       Value: ProvidersCarePlatformLogin
@@ -2103,7 +2103,7 @@ TestCarePartnerParticipantPaneEditEMSSettingAndAddress:
   # Navigate to Participants
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform.navigation_participant$
+      Id: $PAGE.care_platform.navigation_participant$
   # Decrease listing by searching participant's name
     - Type: search_by_text
       Text: $AND_CLI_senior_user1_name$
@@ -3752,7 +3752,7 @@ TestCarePartnerParticipantInfoEditDNRFlag:
   # Return to Participants directory by clicking "Participants" in header
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform.navigation_participant$
+      Id: $PAGE.care_platform.navigation_participant$
   # Search Participant by name
     - Type: search_by_text
       Role: desktopChrome

--- a/tests/cases/case_dummy_test.yaml
+++ b/tests/cases/case_dummy_test.yaml
@@ -23,7 +23,7 @@ DummyTest:
       Value: $AND_CLI_care_platform_url$
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform_login_page.login_button$
+      Id: $PAGE.care_platform_login_page.login_button$
       Greps:
           - var: login_text
             match: "Log In"

--- a/tests/cases/employee_health_portal/case_employee_health_portal_account.yaml
+++ b/tests/cases/employee_health_portal/case_employee_health_portal_account.yaml
@@ -210,6 +210,10 @@ TestEmployeeInformationUpdateNumber:
       Id: $PAGE.employee_health_my_account_modal.my_info_phone_input$
       Attribute: value
       Value: ''
+    - Type: set_checkbox_status
+      Strategy: xpath
+      Option: check
+      Id: $PAGE.employee_health_my_account_modal.notifications_sms_checkbox_checker$
   # Trying to save with empty phone number input
     - Type: click
       Strategy: xpath

--- a/tests/cases/employee_health_portal/case_employee_health_portal_account.yaml
+++ b/tests/cases/employee_health_portal/case_employee_health_portal_account.yaml
@@ -1,10 +1,10 @@
 # CXTB-242: Set “Notifications” in “My account” Modal
 TestEmployeeSettingNotification:
-    Environment: Settings 
-    Roles:
+  Environment: Settings 
+  Roles:
     - Role: desktopChrome
       App: "desktop"
-      Actions:
+  Actions:
   # Calling Login case
     - Type: case
       Value: EmployeeHealthPortalLogIn
@@ -149,11 +149,6 @@ TestEmployeeInformationUpdateNumber:
       Id: $PAGE.employee_health_my_account_modal.modal_title$
     - Type: wait_for_property
       Strategy: xpath
-      Id: $PAGE.employee_health_my_account_modal.my_info_phone_input$ 
-      Property: disabled
-      Value: "false"
-    - Type: wait_for_property
-      Strategy: xpath
       Id: $PAGE.employee_health_my_account_modal.my_info_firstname_input$ 
       Property: disabled
       Value: "true"
@@ -177,7 +172,27 @@ TestEmployeeInformationUpdateNumber:
       Id: $PAGE.employee_health_my_account_modal.my_info_member_id_input$ 
       Property: disabled
       Value: "true"
+    - Type: wait_for_property
+      Strategy: xpath
+      Id: $PAGE.employee_health_my_account_modal.my_info_contact_number_input$
+      Property: disabled
+      Value: "true"
   # Save the current value for phone
+    - Type: get_attribute
+      Strategy: xpath
+      Id: $PAGE.employee_health_my_account_modal.my_info_contact_number_input$
+      Greps:
+      - var: MY_PHONE_CURRENT_PHONE
+        attr: value
+        match: "(.*)"
+  # Change to Notification for a change of number
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.employee_health_my_account_modal.notifications_tab$
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.employee_health_my_account_modal.my_info_phone_input$
+  # Check My Info - Phone number against Notifications - Phone number
     - Type: get_attribute
       Strategy: xpath
       Id: $PAGE.employee_health_my_account_modal.my_info_phone_input$
@@ -212,7 +227,7 @@ TestEmployeeInformationUpdateNumber:
       Asserts:
         - Type: contain
           Var: PHONE_ALERT
-          Value: Please enter a phone number
+          Value: Please enter a contact number
   # Checking alert when using wrong format
     - Type: send_keys
       Strategy: xpath
@@ -228,7 +243,7 @@ TestEmployeeInformationUpdateNumber:
       Asserts:
         - Type: contain
           Var: PHONE_ALERT
-          Value: Please enter a valid phone number
+          Value: Please enter a valid contact number
     - Type: send_keys
       Strategy: xpath
       Id: $PAGE.employee_health_my_account_modal.my_info_phone_input$
@@ -239,10 +254,14 @@ TestEmployeeInformationUpdateNumber:
   # Waiting for notification of success
     - Type: wait_for
       Strategy: xpath
-      Id: $PAGE.employee_health_home_page.alert_updated_info$
+      Id: $PAGE.employee_health_home_page.alert_updated_notification$
   # Navigate into My Account
     - Type: case
       Value: NavigateToMyAccount
+  # Click into Notification
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.employee_health_my_account_modal.notifications_tab$
   # Erase again the phone number
     - Type: loop
       Times: 10
@@ -257,7 +276,7 @@ TestEmployeeInformationUpdateNumber:
       Id: $PAGE.employee_health_my_account_modal.save_changes_button$
     - Type: wait_for
       Strategy: xpath
-      Id: $PAGE.employee_health_home_page.alert_updated_info$
+      Id: $PAGE.employee_health_home_page.alert_updated_notification$
 
 # CXTB-657 Update Email from My Account Portal
 TestEmployeeUpdateAccountEmail:

--- a/tests/cases/employee_health_portal/case_employee_health_portal_login.yaml
+++ b/tests/cases/employee_health_portal/case_employee_health_portal_login.yaml
@@ -27,7 +27,7 @@ TestEmployeeHealthPortalSignUpNewDependent:
   #Check alert messages on required fields
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.employee_health_signup_page.first_name_alert$
+      Id: $PAGE.employee_health_signup_page.first_name_alert$
       Greps:
         - var: ALERT_MESSAGE
           match: "(.*)first name(.*)"
@@ -38,7 +38,7 @@ TestEmployeeHealthPortalSignUpNewDependent:
           Value: "Please enter your first name."
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.employee_health_signup_page.last_name_alert$
+      Id: $PAGE.employee_health_signup_page.last_name_alert$
       Greps:
         - var: ALERT_MESSAGE
           match: "(.*)last name(.*)"
@@ -111,18 +111,18 @@ TestEmployeeHealthPortalForgotPasswordOnLoginPage:
   #Opening the forgot password dialog
     - Type: click
       Strategy: xpath
-      Id : $PAGE.employee_health_login_page.forgot_password_button$
+      Id: $PAGE.employee_health_login_page.forgot_password_button$
   #Closing the dialog
     - Type: click
       Strategy: xpath
-      Id : $PAGE.employee_health_login_page.dialog_cancel_button$
+      Id: $PAGE.employee_health_login_page.dialog_cancel_button$
     - Type: wait_not_visible
       Strategy: xpath
       Id: $PAGE.employee_health_login_page.dialog_submit_button$
   #Opening the forgot password dialog again
     - Type: click
       Strategy: xpath
-      Id : $PAGE.employee_health_login_page.forgot_password_button$
+      Id: $PAGE.employee_health_login_page.forgot_password_button$
   #Submitting the email
     - Type: send_keys
       Strategy: xpath
@@ -130,7 +130,7 @@ TestEmployeeHealthPortalForgotPasswordOnLoginPage:
       Value: $AND_CLI_employee_user1$
     - Type: click
       Strategy: xpath
-      Id : $PAGE.employee_health_login_page.dialog_submit_button$
+      Id: $PAGE.employee_health_login_page.dialog_submit_button$
   #Verify the Thank You text showed up
     - Type: wait_for
       Strategy: xpath
@@ -138,7 +138,7 @@ TestEmployeeHealthPortalForgotPasswordOnLoginPage:
   #Closing the Thank You dialog   
     - Type: click
       Strategy: xpath
-      Id : $PAGE.employee_health_login_page.dialog_close_icon_button$
+      Id: $PAGE.employee_health_login_page.dialog_close_icon_button$
     - Type: wait_not_visible
       Strategy: xpath
-      Id : $PAGE.employee_health_login_page.dialog_submit_button$
+      Id: $PAGE.employee_health_login_page.dialog_submit_button$

--- a/tests/cases/employee_health_portal_mobile_view/case_employee_health_portal_mobile_login.yaml
+++ b/tests/cases/employee_health_portal_mobile_view/case_employee_health_portal_mobile_login.yaml
@@ -31,7 +31,7 @@ TestEHPMobileSignUpNewDependent:
   #Check alert messages on required fields
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.employee_health_signup_page.first_name_alert$
+      Id: $PAGE.employee_health_signup_page.first_name_alert$
       Greps:
         - var: ALERT_MESSAGE
           match: "(.*)first name(.*)"
@@ -42,7 +42,7 @@ TestEHPMobileSignUpNewDependent:
           Value: "Please enter your first name."
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.employee_health_signup_page.last_name_alert$
+      Id: $PAGE.employee_health_signup_page.last_name_alert$
       Greps:
         - var: ALERT_MESSAGE
           match: "(.*)last name(.*)"
@@ -126,18 +126,18 @@ TestEHPMobileForgotPasswordOnLoginPage:
   #Opening the forgot password dialog
     - Type: click
       Strategy: xpath
-      Id : $PAGE.employee_health_login_page.forgot_password_button$
+      Id: $PAGE.employee_health_login_page.forgot_password_button$
   #Closing the dialog
     - Type: click
       Strategy: xpath
-      Id : $PAGE.employee_health_login_page.dialog_cancel_button$
+      Id: $PAGE.employee_health_login_page.dialog_cancel_button$
     - Type: wait_not_visible
       Strategy: xpath
       Id: $PAGE.employee_health_login_page.dialog_submit_button$
   #Opening the forgot password dialog again
     - Type: click
       Strategy: xpath
-      Id : $PAGE.employee_health_login_page.forgot_password_button$
+      Id: $PAGE.employee_health_login_page.forgot_password_button$
   #Submitting the email
     - Type: send_keys
       Strategy: xpath
@@ -145,7 +145,7 @@ TestEHPMobileForgotPasswordOnLoginPage:
       Value: $AND_CLI_employee_user1$
     - Type: click
       Strategy: xpath
-      Id : $PAGE.employee_health_login_page.dialog_submit_button$
+      Id: $PAGE.employee_health_login_page.dialog_submit_button$
   #Verify the Thank You text showed up
     - Type: wait_for
       Strategy: xpath
@@ -153,7 +153,7 @@ TestEHPMobileForgotPasswordOnLoginPage:
   #Closing the Thank You dialog   
     - Type: click
       Strategy: xpath
-      Id : $PAGE.employee_health_login_page.dialog_close_icon_button$
+      Id: $PAGE.employee_health_login_page.dialog_close_icon_button$
     - Type: wait_not_visible
       Strategy: xpath
-      Id : $PAGE.employee_health_login_page.dialog_submit_button$
+      Id: $PAGE.employee_health_login_page.dialog_submit_button$

--- a/tests/cases/employee_health_portal_mobile_view/case_employee_health_portal_mobile_my_info.yaml
+++ b/tests/cases/employee_health_portal_mobile_view/case_employee_health_portal_mobile_my_info.yaml
@@ -174,6 +174,9 @@ TestEHPMobileInformationUpdateNumber:
       Property: disabled
       Value: "true"
     #Go to Notification
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.employee_health_mobile_notifications_page.close_button$
     - Type: click
       Strategy: xpath
       Id: $PAGE.employee_health_mobile_notifications_page.close_button$
@@ -201,29 +204,29 @@ TestEHPMobileInformationUpdateNumber:
       Id: $PAGE.employee_health_my_account_modal.my_info_phone_input$
       Attribute: value
       Value: ''
-  
+    - Type: set_checkbox_status
+      Strategy: xpath
+      Option: check
+      Id: $PAGE.employee_health_my_account_modal.notifications_sms_checkbox_checker$
   # This is not working as the regular Web test. There's no alert when leaving the phone number empty
     #Trying to save with empty phone number input
-  #  - Type: click
-  #    Strategy: xpath
-  #    Id: $PAGE.employee_health_my_account_modal.save_changes_button$
-  #  - Type: click
-  #    Strategy: xpath
-  #    Id: $PAGE.employee_health_mobile_menu_modal.notifications_button$
-  #  - Type: wait_for
-  #    Strategy: xpath
-  #    Id: $PAGE.employee_health_my_account_modal.my_info_phone_alert_message$
-  #  - Type: get_text
-  #    Strategy: xpath
-  #    Id: $PAGE.employee_health_my_account_modal.my_info_phone_alert_message$
-  #    Greps:
-  #      - var: PHONE_ALERT
-  #        match: "(.*)"
-  #  - Type: assert
-  #    Asserts:
-  #      - Type: contain
-  #        Var: PHONE_ALERT
-  #        Value: Please enter a phone number
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.employee_health_my_account_modal.save_changes_button$
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.employee_health_my_account_modal.my_info_phone_alert_message$
+    - Type: get_text
+      Strategy: xpath
+      Id: $PAGE.employee_health_my_account_modal.my_info_phone_alert_message$
+      Greps:
+        - var: PHONE_ALERT
+          match: "(.*)"
+    - Type: assert
+      Asserts:
+        - Type: contain
+          Var: PHONE_ALERT
+          Value: Please enter a contact number
     #Checking alert when using wrong format
     - Type: send_keys
       Strategy: xpath

--- a/tests/cases/employee_health_portal_mobile_view/case_employee_health_portal_mobile_my_info.yaml
+++ b/tests/cases/employee_health_portal_mobile_view/case_employee_health_portal_mobile_my_info.yaml
@@ -142,12 +142,12 @@ TestEHPMobileInformationUpdateNumber:
   #Navigate into My Account
     - Type: case
       Value: EHPMoblieNavigateToMyInfo
-  #Check that phone is the only one enable to edit, all the others are read only
+  #Check that all the fields are read only
     - Type: wait_for_property
       Strategy: xpath
-      Id: $PAGE.employee_health_my_account_modal.my_info_phone_input$ 
+      Id: $PAGE.employee_health_my_account_modal.my_info_contact_number_input$ 
       Property: disabled
-      Value: "false"
+      Value: "true"
     - Type: wait_for_property
       Strategy: xpath
       Id: $PAGE.employee_health_my_account_modal.my_info_firstname_input$ 
@@ -173,6 +173,16 @@ TestEHPMobileInformationUpdateNumber:
       Id: $PAGE.employee_health_my_account_modal.my_info_member_id_input$ 
       Property: disabled
       Value: "true"
+    #Go to Notification
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.employee_health_mobile_notifications_page.close_button$
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.employee_health_mobile_menu_modal.notifications_button$
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.employee_health_mobile_menu_modal.notifications_button$
     #Save the current value for phone
     - Type: get_attribute
       Strategy: xpath
@@ -191,29 +201,37 @@ TestEHPMobileInformationUpdateNumber:
       Id: $PAGE.employee_health_my_account_modal.my_info_phone_input$
       Attribute: value
       Value: ''
+  
+  # This is not working as the regular Web test. There's no alert when leaving the phone number empty
     #Trying to save with empty phone number input
-    - Type: click
-      Strategy: xpath
-      Id: $PAGE.employee_health_my_account_modal.save_changes_button$
-    - Type: wait_for
-      Strategy: xpath
-      Id: $PAGE.employee_health_my_account_modal.my_info_phone_alert_message$
-    - Type: get_text
-      Strategy: xpath
-      Id: $PAGE.employee_health_my_account_modal.my_info_phone_alert_message$
-      Greps:
-        - var: PHONE_ALERT
-          match: "(.*)"
-    - Type: assert
-      Asserts:
-        - Type: contain
-          Var: PHONE_ALERT
-          Value: Please enter a phone number
+  #  - Type: click
+  #    Strategy: xpath
+  #    Id: $PAGE.employee_health_my_account_modal.save_changes_button$
+  #  - Type: click
+  #    Strategy: xpath
+  #    Id: $PAGE.employee_health_mobile_menu_modal.notifications_button$
+  #  - Type: wait_for
+  #    Strategy: xpath
+  #    Id: $PAGE.employee_health_my_account_modal.my_info_phone_alert_message$
+  #  - Type: get_text
+  #    Strategy: xpath
+  #    Id: $PAGE.employee_health_my_account_modal.my_info_phone_alert_message$
+  #    Greps:
+  #      - var: PHONE_ALERT
+  #        match: "(.*)"
+  #  - Type: assert
+  #    Asserts:
+  #      - Type: contain
+  #        Var: PHONE_ALERT
+  #        Value: Please enter a phone number
     #Checking alert when using wrong format
     - Type: send_keys
       Strategy: xpath
       Id: $PAGE.employee_health_my_account_modal.my_info_phone_input$
       Value: 333666
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.employee_health_my_account_modal.save_changes_button$
     - Type: get_text
       Strategy: xpath
       Id: $PAGE.employee_health_my_account_modal.my_info_phone_alert_message$
@@ -224,7 +242,7 @@ TestEHPMobileInformationUpdateNumber:
       Asserts:
         - Type: contain
           Var: PHONE_ALERT
-          Value: Please enter a valid phone number
+          Value: Please enter a valid contact number
     - Type: send_keys
       Strategy: xpath
       Id: $PAGE.employee_health_my_account_modal.my_info_phone_input$
@@ -235,11 +253,11 @@ TestEHPMobileInformationUpdateNumber:
   #Waiting for notification of success
     - Type: wait_for
       Strategy: xpath
-      Id: $PAGE.employee_health_home_page.alert_updated_info$
-    #Navigate to My Info
+      Id: $PAGE.employee_health_home_page.alert_updated_notification$
+    #Navigate to Notification
     - Type: click
       Strategy: xpath
-      Id: $PAGE.employee_health_mobile_menu_modal.my_info_button$
+      Id: $PAGE.employee_health_mobile_menu_modal.notifications_button$
     #Erase again the phone number
     - Type: loop
       Times: 10
@@ -254,7 +272,7 @@ TestEHPMobileInformationUpdateNumber:
       Id: $PAGE.employee_health_my_account_modal.save_changes_button$
     - Type: wait_for
       Strategy: xpath
-      Id: $PAGE.employee_health_home_page.alert_updated_info$
+      Id: $PAGE.employee_health_home_page.alert_updated_notification$
 
 #CXTB-241 “Update password” Workflow in My account Modal
 TestEHPMobileUpdateAccountPassword:

--- a/tests/cases/es_care_partner_platform/case_ch_care_platform_events.yaml
+++ b/tests/cases/es_care_partner_platform/case_ch_care_platform_events.yaml
@@ -289,7 +289,7 @@ TestCHCarePartnerCreateTelehealthEventForParticipant:
   # Telehealth request form window disappears. 
     - Type: wait_not_visible
       Strategy: xpath
-      Id : $PAGE.care_platform_call_portal.telehealth_request_form_header$
+      Id: $PAGE.care_platform_call_portal.telehealth_request_form_header$
   # Schedule listing is updated to include the event you’ve just created.
     - Type: wait_for
       Strategy: xpath

--- a/tests/cases/es_care_partner_platform/case_ch_care_platform_home.yaml
+++ b/tests/cases/es_care_partner_platform/case_ch_care_platform_home.yaml
@@ -61,7 +61,7 @@ TestCHCarePartnerStatusDropdownNotInCall:
   #Changing status back to available
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.user_dropdown_button$
+      Id: $PAGE.care_platform_header.user_dropdown_button$
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.care_platform_header.user_toggle_input$

--- a/tests/cases/es_care_partner_platform/case_es_care_platform_events.yaml
+++ b/tests/cases/es_care_partner_platform/case_es_care_platform_events.yaml
@@ -289,7 +289,7 @@ TestESCarePartnerCreateTelehealthEventForParticipant:
   # Telehealth request form window disappears. 
     - Type: wait_not_visible
       Strategy: xpath
-      Id : $PAGE.care_platform_call_portal.telehealth_request_form_header$
+      Id: $PAGE.care_platform_call_portal.telehealth_request_form_header$
   # Schedule listing is updated to include the event you’ve just created.
     - Type: wait_for
       Strategy: xpath

--- a/tests/cases/es_care_partner_platform/case_es_care_platform_home.yaml
+++ b/tests/cases/es_care_partner_platform/case_es_care_platform_home.yaml
@@ -20,7 +20,7 @@ TestESCarePartnerStatusDropdownNotInCall:
   #Status
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.user_dropdown_button$
+      Id: $PAGE.care_platform_header.user_dropdown_button$
   #Changing status to Off Shift
     - Type: wait_for
       Strategy: xpath
@@ -61,7 +61,7 @@ TestESCarePartnerStatusDropdownNotInCall:
   #Changing status back to available
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.user_dropdown_button$
+      Id: $PAGE.care_platform_header.user_dropdown_button$
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.care_platform_header.user_toggle_input$
@@ -110,7 +110,7 @@ TestESCarePartnerAccessAndReviewTeamMembersAvailability:
   # Verify that the list shows care partner users and current statuses.
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform_header.users_dropdown_list$
+      Id: $PAGE.care_platform_header.users_dropdown_list$
       Greps:
       - var: USERS_LIST_TEXT
         match: '[\s\S]*' # using single quotes due to YAML issues with regex and double quotes.

--- a/tests/cases/helpers/case_helper_es_care_platform_providers.yaml
+++ b/tests/cases/helpers/case_helper_es_care_platform_providers.yaml
@@ -9,7 +9,7 @@ ESProvidersCarePlatformLogin:
       Value: $AND_CLI_easterseals_care_platform_url$
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform_login.login_button$
+      Id: $PAGE.care_platform_login.login_button$
       Greps:
       - var: login_text
         match: "Log In"

--- a/tests/cases/helpers/case_helpers_care_platform.yaml
+++ b/tests/cases/helpers/case_helpers_care_platform.yaml
@@ -1419,6 +1419,14 @@ CarePlatformUpdateInfo:
       Id: $PAGE.care_platform_myaccount_info.contact_number$
       Attribute: disabled
       Value: true
+    - Type: get_attribute
+      Strategy: xpath
+      Id: $PAGE.care_platform_myaccount_info.contact_number$
+      Greps:
+        - var: CONTACT_NUMBER
+          attr: value
+          condition: nempty
+          match: "(.*)"
   #Go to Text Notification tab to change phone number
     - Type: click
       Strategy: xpath
@@ -1426,6 +1434,31 @@ CarePlatformUpdateInfo:
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.care_platform_myaccount_info.phone_input$
+  #Check that Contact Number in My Info is equal to Phone Number in Text Notification
+    - Type: get_attribute
+      Strategy: xpath
+      Id: $PAGE.care_platform_myaccount_info.phone_input$
+      Greps:
+        - var: PHONE_NUMBER
+          attr: value
+          condition: nempty
+          match: "(.*)"
+    - Type: assert
+      Asserts:
+        - Type: eq
+          Var: PHONE_NUMBER
+          Value: $AND_CLI_CONTACT_NUMBER$
+  #Set a Phone Input
+    - Type: send_keys
+      Strategy: xpath
+      Id: $PAGE.care_platform_myaccount_info.phone_input$
+      Value: 4373334444
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.care_platform_myaccount_info.notification_text_save_button$  
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.care_platform_notifications.saved_account_info_notification$
   #Check invalid phone number error message
     - Type: send_keys
       Strategy: xpath
@@ -1433,7 +1466,7 @@ CarePlatformUpdateInfo:
       Value: "backspace"
     - Type: click
       Strategy: xpath
-      Id: $PAGE.care_platform_myaccount_info.save_changes_button$  
+      Id: $PAGE.care_platform_myaccount_info.notification_text_save_button$  
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.care_platform_myaccount_info.phone_error_message$
@@ -1445,9 +1478,6 @@ CarePlatformUpdateInfo:
     - Type: click
       Strategy: xpath
       Id: $PAGE.care_platform_myaccount_info.text_notification_tab$
-  #Check checkboxes
-
-
   #Use button cancel of the modal
     - Type: click
       Strategy: xpath

--- a/tests/cases/helpers/case_helpers_care_platform.yaml
+++ b/tests/cases/helpers/case_helpers_care_platform.yaml
@@ -1003,7 +1003,7 @@ CarePlatformUpdatePassword:
   #Click in Update Password
     - Type: click
       Strategy: xpath
-      Id: $PAGE.care_platform_myaccount_info.update_password_button$
+      Id: $PAGE.care_platform_myaccount_info.update_password_tab$
   #Verify the elements
     - Type: wait_for
       Strategy: xpath
@@ -1068,7 +1068,7 @@ CarePlatformUpdatePassword:
   #Click in Update Password
     - Type: click
       Strategy: xpath
-      Id: $PAGE.care_platform_myaccount_info.update_password_button$
+      Id: $PAGE.care_platform_myaccount_info.update_password_tab$
   #Fill the fields
     - Type: send_keys
       Strategy: xpath
@@ -1115,7 +1115,7 @@ CarePlatformUpdatePassword:
   #Click in Update Password
     - Type: click
       Strategy: xpath
-      Id: $PAGE.care_platform_myaccount_info.update_password_button$
+      Id: $PAGE.care_platform_myaccount_info.update_password_tab$
   #Set the password var to the new value
     - Type: set_env_var
       Value: $AND_CLI_ENV_PASS_STORE$
@@ -1157,7 +1157,7 @@ AlternativeCarePlatformUpdatePassword:
   #Click in Update Password
     - Type: click
       Strategy: xpath
-      Id: $PAGE.care_platform_myaccount_info.update_password_button$
+      Id: $PAGE.care_platform_myaccount_info.update_password_tab$
   #Verify the elements
     - Type: wait_for
       Strategy: xpath
@@ -1222,7 +1222,7 @@ AlternativeCarePlatformUpdatePassword:
   #Click in Update Password
     - Type: click
       Strategy: xpath
-      Id: $PAGE.care_platform_myaccount_info.update_password_button$
+      Id: $PAGE.care_platform_myaccount_info.update_password_tab$
   #Fill the fields
     - Type: send_keys
       Strategy: xpath
@@ -1269,7 +1269,7 @@ AlternativeCarePlatformUpdatePassword:
   #Click in Update Password
     - Type: click
       Strategy: xpath
-      Id: $PAGE.care_platform_myaccount_info.update_password_button$
+      Id: $PAGE.care_platform_myaccount_info.update_password_tab$
   #Set the password var to the new value
     - Type: set_env_var
       Value: $AND_CLI_ENV_PASS_STORE$
@@ -1300,17 +1300,17 @@ CarePlatformUpdateInfo:
 #Going to My Account
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.user_dropdown_button$
+      Id: $PAGE.care_platform_header.user_dropdown_button$
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.myaccount_menu_button$  
+      Id: $PAGE.care_platform_header.myaccount_menu_button$  
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.care_platform_myaccount_info.modal_title$
   #Saving original firstname, and adding a 1 to form input
     - Type: get_attribute
       Strategy: xpath
-      Id : $PAGE.care_platform_myaccount_info.firstname_input$
+      Id: $PAGE.care_platform_myaccount_info.firstname_input$
       Greps:
         - var: FIRSTNAME_ORIG
           attr: value
@@ -1322,10 +1322,10 @@ CarePlatformUpdateInfo:
       Value: '1'
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_myaccount_info.modal_title$
+      Id: $PAGE.care_platform_myaccount_info.modal_title$
     - Type: get_attribute
       Strategy: xpath
-      Id : $PAGE.care_platform_myaccount_info.firstname_input$
+      Id: $PAGE.care_platform_myaccount_info.firstname_input$
       Greps:
         - var: FIRSTNAME_NEW
           attr: value
@@ -1345,7 +1345,7 @@ CarePlatformUpdateInfo:
       Value: true
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_myaccount_info.save_changes_button$  
+      Id: $PAGE.care_platform_myaccount_info.save_changes_button$  
   #Wait for the success alert message
     - Type: wait_for
       Strategy: xpath
@@ -1357,10 +1357,10 @@ CarePlatformUpdateInfo:
   # Open the user dropdown on header and verify that the name in the dropdown reflects the new change to the firstname
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.user_dropdown_button$
+      Id: $PAGE.care_platform_header.user_dropdown_button$
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform_header.user_dropdown_user_name$ # Update TC
+      Id: $PAGE.care_platform_header.user_dropdown_user_name$ # Update TC
       Greps:
         - var: NEW_NAME
           condition: nempty
@@ -1373,7 +1373,7 @@ CarePlatformUpdateInfo:
   #Going again to the My Account Modal
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.myaccount_menu_button$  
+      Id: $PAGE.care_platform_header.myaccount_menu_button$  
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.care_platform_myaccount_info.modal_title$
@@ -1384,20 +1384,20 @@ CarePlatformUpdateInfo:
       Value: "backspace"
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_myaccount_info.save_changes_button$
+      Id: $PAGE.care_platform_myaccount_info.save_changes_button$
     - Type: wait_not_visible
       Strategy: xpath
       Id: $PAGE.care_platform_myaccount_info.success_alert_msg$
       Time: 10
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.user_dropdown_button$
+      Id: $PAGE.care_platform_header.user_dropdown_button$
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.myaccount_menu_button$
+      Id: $PAGE.care_platform_header.myaccount_menu_button$
     - Type: get_attribute
       Strategy: xpath
-      Id : $PAGE.care_platform_myaccount_info.firstname_input$
+      Id: $PAGE.care_platform_myaccount_info.firstname_input$
       Greps:
         - var: BACK_NAME
           attr: value
@@ -1408,21 +1408,50 @@ CarePlatformUpdateInfo:
         - Type: eq
           Var: BACK_NAME
           Value: $AND_CLI_FIRSTNAME_ORIG$
-  #Check error on phone number
+  #Check error on phone number #Phone number is no longer an input in this view
+    - Type: wait_for_attribute
+      Strategy: xpath
+      Id: $PAGE.care_platform_myaccount_info.email_input$
+      Attribute: disabled
+      Value: true
+    - Type: wait_for_attribute
+      Strategy: xpath
+      Id: $PAGE.care_platform_myaccount_info.contact_number$
+      Attribute: disabled
+      Value: true
+  #Go to Text Notification tab to change phone number
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.care_platform_myaccount_info.text_notification_tab$
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.care_platform_myaccount_info.phone_input$
+  #Check invalid phone number error message
     - Type: send_keys
       Strategy: xpath
       Id: $PAGE.care_platform_myaccount_info.phone_input$
       Value: "backspace"
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_myaccount_info.save_changes_button$
+      Id: $PAGE.care_platform_myaccount_info.save_changes_button$  
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.care_platform_myaccount_info.phone_error_message$
+  #Change tab
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.care_platform_myaccount_info.my_info_tab$
+  #Go back to text notification tab
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.care_platform_myaccount_info.text_notification_tab$
+  #Check checkboxes
+
+
   #Use button cancel of the modal
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_myaccount_info.cancel_button$
+      Id: $PAGE.care_platform_myaccount_info.cancel_button$
     - Type: wait_not_visible
       Strategy: xpath
       Id: $PAGE.care_platform_myaccount_info.modal_title$
@@ -1670,18 +1699,18 @@ ForgotPasswordCarePlatformLoginLink:
   #Opening the forgot password dialog
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_login.forgot_password_button$
+      Id: $PAGE.care_platform_login.forgot_password_button$
   #Closing the dialog
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_login.dialog_cancel_button$
+      Id: $PAGE.care_platform_login.dialog_cancel_button$
     - Type: wait_not_visible
       Strategy: xpath
       Id: $PAGE.care_platform_login.dialog_submit_button$
   #Opening the forgot password dialog
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_login.forgot_password_button$
+      Id: $PAGE.care_platform_login.forgot_password_button$
   #Submitting the email
     - Type: send_keys
       Strategy: xpath
@@ -1689,7 +1718,7 @@ ForgotPasswordCarePlatformLoginLink:
       Value: $AND_CLI_carepartner_user1$
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_login.dialog_submit_button$
+      Id: $PAGE.care_platform_login.dialog_submit_button$
   #Verify the Thank You text showed up
     - Type: get_text  
       Strategy: xpath
@@ -1706,10 +1735,10 @@ ForgotPasswordCarePlatformLoginLink:
   #Closing the Thank You dialog   
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_login.dialog_close_icon_button$
+      Id: $PAGE.care_platform_login.dialog_close_icon_button$
     - Type: wait_not_visible
       Strategy: xpath
-      Id : $PAGE.care_platform_login.dialog_submit_button$
+      Id: $PAGE.care_platform_login.dialog_submit_button$
   #Step 6 and 7 needs access to the email account provided in previous step
   #Access to the confirmation email message, and link within to set new password
   #These steps cannot be done 
@@ -1885,7 +1914,7 @@ CarePartnerEditParticipantNavigation:
 # Navigate to Participants
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform.navigation_participant$
+      Id: $PAGE.care_platform.navigation_participant$
   # Limit listing by searching name
     - Type: search_by_text
       Role: desktopChrome
@@ -1935,7 +1964,7 @@ CarePartnerParticipantPaneNavigation:
   # Navigate to Participants.
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform.navigation_participant$
+      Id: $PAGE.care_platform.navigation_participant$
   # Limit listing by searching name.
     - Type: search_by_text
       Role: desktopChrome
@@ -1980,7 +2009,7 @@ CarePartnerParticipantCallPortalNavigation:
   # Navigate to Participants.
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform.navigation_participant$
+      Id: $PAGE.care_platform.navigation_participant$
   # Limit listing by searching name.
     - Type: search_by_text
       Role: desktopChrome
@@ -2029,7 +2058,7 @@ CarePartnerToastValidation:
           Value: "1"
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform.carepartner_toast_notification$
+      Id: $PAGE.care_platform.carepartner_toast_notification$
       Greps:
         - var: TOAST_MESSAGE
           match: "(.*)"
@@ -2051,7 +2080,7 @@ CarePartnerParticipantRecordsNavigation:
   # Navigate to Participants
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform.navigation_participant$
+      Id: $PAGE.care_platform.navigation_participant$
   # Decrease listing by searching participant's name
     - Type: search_by_text
       Role: desktopChrome
@@ -2219,7 +2248,7 @@ AddEditOrDeleteParticipantVendorInfo:
       Var: MODAL_NAME
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform_edit_participants_vendor.modal_title_label$
+      Id: $PAGE.care_platform_edit_participants_vendor.modal_title_label$
       Greps:
         - var: MODAL_TITLE
           match: "(.*)"
@@ -2292,7 +2321,7 @@ AddEditOrDeleteParticipantVendorInfo:
   # Validate if the new change is applied
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform_edit_participants_vendor.name_vendor_record$
+      Id: $PAGE.care_platform_edit_participants_vendor.name_vendor_record$
       Greps:
         - var: CATEGORY_VENDOR_NAME
           match: "(.*)"
@@ -3410,11 +3439,11 @@ MakeMedicalTransferWhileOnCall:
   # Telehealth request form window disappears.
     - Type: wait_not_visible
       Strategy: xpath
-      Id : $PAGE.care_platform_call_portal.telehealth_request_form_header$
+      Id: $PAGE.care_platform_call_portal.telehealth_request_form_header$
   # Verify "End Call" button has been replaced with "Leave Call" button.
     - Type: wait_for
       Strategy: xpath
-      Id : $PAGE.care_platform_call_portal.leave_call_btn$
+      Id: $PAGE.care_platform_call_portal.leave_call_btn$
 
 AlternativeCarePartnerLogout:
   Roles:

--- a/tests/cases/helpers/case_helpers_care_platform_providers.yaml
+++ b/tests/cases/helpers/case_helpers_care_platform_providers.yaml
@@ -9,7 +9,7 @@ ProvidersCarePlatformLogin:
       Value: $AND_CLI_care_platform_url$
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform_login.login_button$
+      Id: $PAGE.care_platform_login.login_button$
       Greps:
       - var: login_text
         match: "Log In"
@@ -366,17 +366,17 @@ ProviderSetStateCredential:
 #Going to My Account
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.user_dropdown_button$
+      Id: $PAGE.care_platform_header.user_dropdown_button$
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform_header.myaccount_menu_button$
+      Id: $PAGE.care_platform_header.myaccount_menu_button$
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.care_platform_myaccount_info.modal_title$
   #Select credentials to answer call
     - Type: click
       Strategy: xpath
-      Id : $PAGE.providers_account_modal.credentials_navigation_tab$
+      Id: $PAGE.providers_account_modal.credentials_navigation_tab$
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.providers_account_modal.credentials_content$

--- a/tests/cases/helpers/case_helpers_ch_care_platform.yaml
+++ b/tests/cases/helpers/case_helpers_ch_care_platform.yaml
@@ -373,7 +373,7 @@ VerifyCHUserIsOffline:
       Id: $PAGE.care_platform_header.offline_ch_carepartner_element$
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform_header.offline_ch_carepartner_element$
+      Id: $PAGE.care_platform_header.offline_ch_carepartner_element$
       Greps:
         - var: CARE_PARTNER_ELEMENT
           match: "(.*)"
@@ -403,7 +403,7 @@ VerifyCHUserIsOnline:
       Id: $PAGE.care_platform_header.online_ch_carepartner_element$
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform_header.online_ch_carepartner_element$
+      Id: $PAGE.care_platform_header.online_ch_carepartner_element$
       Greps:
         - var: CARE_PARTNER_ELEMENT
           match: "(.*)"
@@ -499,7 +499,7 @@ CHCarePartnerParticipantCallPortalNavigation:
   # Navigate to Participants.
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform.navigation_participant$
+      Id: $PAGE.care_platform.navigation_participant$
   # Limit listing by searching name.
     - Type: search_by_text
       Role: desktopChrome

--- a/tests/cases/helpers/case_helpers_es_care_platform.yaml
+++ b/tests/cases/helpers/case_helpers_es_care_platform.yaml
@@ -379,7 +379,7 @@ VerifyESUserIsOffline:
       Id: $PAGE.care_platform_header.offline_es_carepartner_element$
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform_header.offline_es_carepartner_element$
+      Id: $PAGE.care_platform_header.offline_es_carepartner_element$
       Greps:
         - var: CARE_PARTNER_ELEMENT
           match: "(.*)"
@@ -410,7 +410,7 @@ VerifyESUserIsOnline:
       Id: $PAGE.care_platform_header.online_es_carepartner_element$
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform_header.online_es_carepartner_element$
+      Id: $PAGE.care_platform_header.online_es_carepartner_element$
       Greps:
         - var: CARE_PARTNER_ELEMENT
           match: "(.*)"
@@ -506,7 +506,7 @@ ESCarePartnerParticipantCallPortalNavigation:
   # Navigate to Participants.
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform.navigation_participant$
+      Id: $PAGE.care_platform.navigation_participant$
   # Limit listing by searching name.
     - Type: search_by_text
       Role: desktopChrome

--- a/tests/cases/onboarders_care_platform/case_onboarders_facilities.yaml
+++ b/tests/cases/onboarders_care_platform/case_onboarders_facilities.yaml
@@ -112,7 +112,7 @@ TestOnboardersAccessFacilitiesDirectoryFilter:
     - Type: click
       Strategy: xpath
       Id: $PAGE.care_platform_facility.first_facility$
-    - Type : wait_for
+    - Type: wait_for
       Strategy: xpath
       Id: $PAGE.care_platform_facility.facility_name$
     - Type: click

--- a/tests/cases/onboarders_care_platform/case_onboarders_staff_members.yaml
+++ b/tests/cases/onboarders_care_platform/case_onboarders_staff_members.yaml
@@ -531,7 +531,7 @@ TestOnboarderStaffMemberPaneDeactivateStaffMemberAccountForCarePlatform:
   # Verify if logged in and user is deactivated, it should kick out the user from the app.
     - Type: click
       Strategy: xpath
-      Id : $PAGE.care_platform.navigation_participant$
+      Id: $PAGE.care_platform.navigation_participant$
       Role: desktopChrome1
     - Type: wait_for
       Strategy: id

--- a/tests/cases/providers_care_platform/case_providers_account.yaml
+++ b/tests/cases/providers_care_platform/case_providers_account.yaml
@@ -330,7 +330,7 @@ TestProviderLogOutPortalGoOffShift:
       Id: $PAGE.care_platform_header.offline_carepartner1_element$
     - Type: get_text
       Strategy: xpath
-      Id : $PAGE.care_platform_header.offline_carepartner1_element$
+      Id: $PAGE.care_platform_header.offline_carepartner1_element$
       Greps:
         - var: CARE_PARTNER_ELEMENT
           match: "(.*)"

--- a/tests/cases/providers_care_platform/case_providers_call_history.yaml
+++ b/tests/cases/providers_care_platform/case_providers_call_history.yaml
@@ -427,11 +427,11 @@ TestProviderReviewParticipantsCallHistoryAndAccessCallRecordings:
   # Telehealth request form window disappears.
     - Type: wait_not_visible
       Strategy: xpath
-      Id : $PAGE.care_platform_call_portal.telehealth_request_form_header$
+      Id: $PAGE.care_platform_call_portal.telehealth_request_form_header$
   # Verify "End Call" button has been replaced with "Leave Call" button.
     - Type: wait_for
       Strategy: xpath
-      Id : $PAGE.care_platform_call_portal.leave_call_btn$
+      Id: $PAGE.care_platform_call_portal.leave_call_btn$
   # Log in as a provider and join the call
     - Type: case
       Value: ProvidersCarePlatformLogin

--- a/tests/cases/providers_care_platform/case_providers_home.yaml
+++ b/tests/cases/providers_care_platform/case_providers_home.yaml
@@ -254,10 +254,10 @@ TestProvidersAnswerSNFCallAndCompletesSession:
     # Click on the corresponding call on the Home page to and click on the "Answer" button.
     - Type: wait_for
       Strategy: xpath
-      Id : $PAGE.providers_home_page.on_demand_based_on_participant_name$
+      Id: $PAGE.providers_home_page.on_demand_based_on_participant_name$
     - Type: click
       Strategy: xpath
-      Id : $PAGE.providers_home_page.on_demand_based_on_participant_name$
+      Id: $PAGE.providers_home_page.on_demand_based_on_participant_name$
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.providers_call_handling_page.answer_call_button$
@@ -633,11 +633,11 @@ TestProvidersReturnToCallPortalAndAndCompletesSession:
   # Telehealth request form window disappears.
     - Type: wait_not_visible
       Strategy: xpath
-      Id : $PAGE.care_platform_call_portal.telehealth_request_form_header$
+      Id: $PAGE.care_platform_call_portal.telehealth_request_form_header$
   # Verify "End Call" button has been replaced with "Leave Call" button.
     - Type: wait_for
       Strategy: xpath
-      Id : $PAGE.care_platform_call_portal.leave_call_btn$
+      Id: $PAGE.care_platform_call_portal.leave_call_btn$
   # Log in as a provider and join the call
     - Type: case
       Value: ProvidersCarePlatformLogin
@@ -1391,11 +1391,11 @@ TestProviderSeniorSeeCallAppearInQueueAssignAndReviewDetails:
   # Telehealth request form window disappears.
     - Type: wait_not_visible
       Strategy: xpath
-      Id : $PAGE.care_platform_call_portal.telehealth_request_form_header$
+      Id: $PAGE.care_platform_call_portal.telehealth_request_form_header$
   # Verify "End Call" button has been replaced with "Leave Call" button.
     - Type: wait_for
       Strategy: xpath
-      Id : $PAGE.care_platform_call_portal.leave_call_btn$
+      Id: $PAGE.care_platform_call_portal.leave_call_btn$
   # Log in as a provider and join the call
     - Type: case
       Value: ProvidersCarePlatformLogin

--- a/tests/page_objects/care_platform_page.yaml
+++ b/tests/page_objects/care_platform_page.yaml
@@ -66,15 +66,16 @@ care_platform_header:
 care_platform_myaccount_info:
   modal_title: //*[@id='modals']//h4[contains(text(),'My Account')]
   close_modal_button: //*[@id='modals']//button[contains(text(),'Close')]
+  my_info_tab: //nav//button[contains(text(),'My Info')]
   firstname_input: //input[@id='firstName']
   email_input: //input[@id='email']
-  phone_input: //*[@id='phone']
+  contact_number: //div[@id='modals']//div[contains(@class,'input-group')][contains(.,'Contact Number')]/input
   phone_error_message: //*[@id='modals']//div[contains(text(),'Please enter a valid contact number')]
   save_changes_button: //*[@id='modals']//button[text()='Save Changes']
   cancel_button: //*[@id='modals']//button[text()='Cancel']
   success_alert_msg: //div[@class='Toastify']//div[contains(text(),'Account info updated')]
   password_updated_successfully_alert_msg: //div[@class='Toastify']//div[contains(text(),'Password updated successfully')]  
-  update_password_button: //nav//button[contains(text(),'Update Password')]
+  update_password_tab: //nav//button[contains(text(),'Update Password')]
   current_password_label: //label[@for='currentPassword']
   current_password_input: //input[@id='currentPassword']
   new_password_label: //label[@for='password']
@@ -83,7 +84,12 @@ care_platform_myaccount_info:
   confirm_new_password_input: //input[@id='passwordConfirmation']
   change_my_password_button: //button[contains(text(),'Change My Password')]
   password_requirements_alert_text: //div[contains(@class,'red')][contains(text(),'Password does not meet the requirements')]
-  
+  text_notification_tab: //nav//button[contains(text(),'Text Notification')]
+  phone_input: //*[@id='phone']
+  incoming_call_checkbox: incomingCallNotification
+  long_wait_checkbox: fiveMinuteNotification
+  notification_text_save_button: //*[@id='button-save-changes']
+
 care_platform_logout_modal:
   stay_on_shift_button: //button[contains(text(),'Stay On Shift')]
   go_off_shift_button: //button[contains(text(),'Go Off Shift')]
@@ -671,6 +677,7 @@ care_platform_notifications:
   dismiss_notification_button: //div[@class='Toastify']//button[text()='Dismiss']
   device_changes_saved_notification: //div[@class='Toastify']//div[contains(text(),'Facility device changes saved')]
   refresh_staff_notification: //div[@class='Toastify']//div[contains(text(),'Account status refreshed')]
+  saved_account_info_notification: //div[@class='Toastify']//div[contains(text(),'Settings updated successfully')]
 
 care_platform_facility:
   search_button: searchButton

--- a/tests/page_objects/employee_health_portal_page.yaml
+++ b/tests/page_objects/employee_health_portal_page.yaml
@@ -78,6 +78,7 @@ employee_health_my_account_modal:
   cancel_button: //button[text()='Cancel']
   notifications_email_checkbox_input: //*[@id='minBeforeAppointmentToEmail']
   notifications_sms_checkbox_input: //*[@id='minBeforeAppointmentToText']
+  notifications_sms_checkbox_checker: //*[@id='minBeforeAppointmentToText']/ancestor::label
   notifications_email_checkbox: //*[@id='minBeforeAppointmentToEmail']/following-sibling::span
   notifications_sms_checkbox: //*[@id='minBeforeAppointmentToText']/following-sibling::span
   my_info_contact_number_input: //div[contains(@class,'input-group')][contains(.,'Contact Number')]/input

--- a/tests/page_objects/employee_health_portal_page.yaml
+++ b/tests/page_objects/employee_health_portal_page.yaml
@@ -73,20 +73,21 @@ employee_health_my_account_modal:
   notifications_tab: //*[@id='modals']//nav/button[text()='Notifications']
   my_info_tab: //*[@id='modals']//nav/button[text()='My Info']
   update_password_tab: //nav/button[text()='Update Password']
-  notifications_text: //div[@tab-title='Notifications']/form
+  notifications_text: //div[@tab-title='Notifications']/form/p[contains(text(),'minutes')]
   save_changes_button: //button[text()='Save Changes']
   cancel_button: //button[text()='Cancel']
   notifications_email_checkbox_input: //*[@id='minBeforeAppointmentToEmail']
   notifications_sms_checkbox_input: //*[@id='minBeforeAppointmentToText']
   notifications_email_checkbox: //*[@id='minBeforeAppointmentToEmail']/following-sibling::span
   notifications_sms_checkbox: //*[@id='minBeforeAppointmentToText']/following-sibling::span
+  my_info_contact_number_input: //div[contains(@class,'input-group')][contains(.,'Contact Number')]/input
   my_info_phone_input: //input[@id='phone']
   my_info_phone_alert_message: //label[@for='phone']//following-sibling::div[@aria-hidden='false']//div[contains(@class,'color-red-400')]
-  my_info_firstname_input: //input[@id='firstName']
-  my_info_lastname_input: //*[@id='lastName']
-  my_info_email_input: //*[@id='email']
-  my_info_date_of_birth_input: //*[@id='dateOfBirth']
-  my_info_member_id_input: //*[@id='memberIdentifier']
+  my_info_firstname_input: //div[contains(@class,'input-group')][contains(.,'First Name')]/input
+  my_info_lastname_input: //div[contains(@class,'input-group')][contains(.,'Last Name')]/input
+  my_info_email_input: //div[contains(@class,'input-group')][contains(.,'Email')]/input
+  my_info_date_of_birth_input: //div[contains(@class,'input-group')][contains(.,'Date of Birth')]/input
+  my_info_member_id_input: //div[contains(@class,'input-group')][contains(.,'Member ID')]/input
   update_email_tab: //nav/button[text()='Update Email']
   update_email_current: //*[@tab-title='Update Email']//input[contains(@class,'input')]
   update_email_new: //*[@id='email']
@@ -170,7 +171,7 @@ employee_health_mobile_menu_modal:
 
 employee_health_mobile_notifications_page:
     save_changes_button: //button[text()= 'Save Changes']
-    notifications_text: //*[@id='menus']//form
+    notifications_text: //*[@id='menus']//form/p[contains(text(),'minutes')]
     close_button: //*[@id='menus']//header//button
 
 employee_health_mobile_password_page:


### PR DESCRIPTION
Fixes on these tests:

- TestCarePartnerUpdateInfoAccount
- TestEmployeeSettingNotification
- TestEmployeeInformationUpdateNumber
- TestOnboardersAccessMyAcountWindowAndReviewMyInfo
- TestProviderUpdateAccountInfo
- TestEHPMobileSettingNotification
- TestEHPMobileInformationUpdateNumber

![image](https://github.com/neveralone-chs-org/TestRay/assets/118225389/0a42e6e7-7ac7-4533-a9dd-e47c9739e607)
![image](https://github.com/neveralone-chs-org/TestRay/assets/118225389/2a9ee7cc-34b2-4657-9cc2-0ae8f99d10f2)
![image](https://github.com/neveralone-chs-org/TestRay/assets/118225389/b9e6dd59-a024-4a09-baac-e27871d65f7c)
![image](https://github.com/neveralone-chs-org/TestRay/assets/118225389/d0839cae-b653-4168-b697-abb3ad897e98)
![image](https://github.com/neveralone-chs-org/TestRay/assets/118225389/8bcf6ea1-ff36-4894-bab1-630cf34bbaae)
![image](https://github.com/neveralone-chs-org/TestRay/assets/118225389/ae274906-e966-46c2-a62f-102be8c327c7)
