### PR TITLE
CXTB-736 ProviderCarePlatform - Can Click and View Participant’s Follow-up Tickets Information

### DIFF
--- a/tests/cases/helpers/case_helpers_care_platform.yaml
+++ b/tests/cases/helpers/case_helpers_care_platform.yaml
@@ -2216,6 +2216,8 @@ CarePartnerParticipantRecordsNavigation:
       Strategy: xpath
       Id: $PAGE.care_platform_participant.senior_complete_name$
   # Go to Records
+    - Type: sleep
+      Time: 0.5
     - Type: click
       Strategy: xpath
       Id: $PAGE.care_platform_participant_details.records_button$

--- a/tests/cases/helpers/case_helpers_care_platform_providers.yaml
+++ b/tests/cases/helpers/case_helpers_care_platform_providers.yaml
@@ -366,6 +366,8 @@ ProviderCallParticipant:
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.care_platform_call_portal.events_subtitle$
+    - Type: sleep
+      Time: 1
     - Type: click_js
       Strategy: xpath
       Id: $PAGE.care_platform_call_portal.call_participant_btn$

--- a/tests/cases/providers_care_platform/case_providers_participants.yaml
+++ b/tests/cases/providers_care_platform/case_providers_participants.yaml
@@ -668,3 +668,168 @@ TestProviderAttemptAnOnDemandCallToParticipantsDeviceThatIsMissed:
       Strategy: xpath
       Id: $PAGE.providers_call_handling_page.no_message_button$
       Role: desktopChrome
+
+# CXTB-177 Can Click and View Participant’s Follow-up Tickets Information
+TestProviderCanClickAndViewParticipantsFollowUpTicketsInformation:
+  Environment: Settings
+  Vars:
+  # Log out option
+    LOGOUT_OPTION: "Go Off Shift"
+  Precases:
+    - LoginNeverAloneHelper
+    - ProviderNewCleaner
+    - SeniorCleanPrompts
+  Aftercases:
+    - CarePlatformLogout
+    - TerminateApp
+  Roles:
+    - Role: localiOS
+      App: NeverAlone
+    - Role: desktopChrome
+      App: desktop
+  Actions:
+  # Call Participant logged in as a Provider.
+    - Type: case
+      Value: CreateAFollowUpForParticipantCall
+  # Navigate again to home
+    - Type: click
+      Strategy: xpath
+      Role: desktopChrome
+      Id: $PAGE.providers_home_page.home_button$
+    - Type: wait_for
+      Strategy: xpath
+      Role: desktopChrome
+      Id: $PAGE.providers_home_page.home_title$
+    # Select a Follow-Up Call
+    - Type: wait_for
+      Strategy: xpath
+      Role: desktopChrome
+      Id: $PAGE.providers_home_page.follow_up_calls$
+    - Type: click
+      Strategy: xpath
+      Role: desktopChrome
+      Id: $PAGE.providers_home_page.follow_up_calls$
+    - Type: sleep
+      Role: desktopChrome
+      Time: 1
+    # Close Follow-Up
+    - Type: case
+      Value: CleanUsedFollowUp
+  # Navigate to Records.
+    - Type: case
+      Value: CarePartnerParticipantRecordsNavigation
+  # Click the "Follow-up tickets" profile tab.
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_records.follow_up_tickets_tab$
+      Role: desktopChrome
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_records.follow_up_tickets_tab$
+      Role: desktopChrome
+    # Page refreshes to show a full page view of all the participant’s follow-up tickets:
+    # Left "Ticket history"
+    # Right "Active tickets"
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_records_follow_up_tickets.ticket_history_title$
+      Role: desktopChrome
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_records_follow_up_tickets.active_tickets_title$
+      Role: desktopChrome
+    # Review the "Active tickets" section listing.
+    # Shows active follow-up tickets for the participant.
+    # Click to expand a ticket.
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_records_follow_up_tickets.active_follow_up_ticket_based_on_name$
+      Role: desktopChrome
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_records_follow_up_tickets.active_follow_up_ticket_based_on_name$
+      Role: desktopChrome
+    # Select Follow Up tab
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.providers_participants_records_page.follow_up_tickets_tab$
+      Role: desktopChrome
+    - Type: get_attribute
+      Strategy: xpath
+      Id: $PAGE.providers_participants_records_page.follow_up_tickets_tab$
+      Role: desktopChrome
+      Greps:
+        - var: ACTIVE_CLASS
+          attr: class
+          condition: nempty
+          match: "(.*)"
+    - Type: assert
+      Asserts:
+        - Type: contain
+          Var: ACTIVE_CLASS
+          Value: 'active' 
+  # Left "Ticket history"
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_records_follow_up_tickets.ticket_history_title$
+      Role: desktopChrome
+  # Right "Active tickets"
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_records_follow_up_tickets.active_tickets_title$
+      Role: desktopChrome
+  # Review the "Ticket history" section listing.
+    # Click to expand a row.
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.providers_follow_up_call_details_page.first_follow_up_row$
+      Role: desktopChrome
+    - Type: click
+      Strategy: xpath
+      Id: $PAGE.providers_follow_up_call_details_page.first_follow_up_row$
+      Role: desktopChrome
+    # Expands and shows creation information, and additional details about the task that was completed.
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_records_follow_up_tickets.expanded_ticket_content$
+      Role: desktopChrome
+    - Type: get_attribute
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_records_follow_up_tickets.expanded_ticket_content$
+      Role: desktopChrome
+      Greps:
+        - var: COMPLETED_LABEL
+          attr: textContent
+          condition: nempty
+          match: "(.*)"
+    - Type: assert
+      Asserts:
+        - Type: contain
+          Var: COMPLETED_LABEL
+          Value: Completed
+    - Type: assert
+      Asserts:
+        - Type: contain
+          Var: COMPLETED_LABEL
+          Value: Reason for Closing
+    # Verify that listing includes all completed Care Partner follow-up tickets. The main table displays the key summary information.
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_records_follow_up_tickets.ticket_history_completed_header_label$
+      Role: desktopChrome
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_records_follow_up_tickets.ticket_history_loe_header_label$
+      Role: desktopChrome
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_records_follow_up_tickets.ticket_history_type_header_label$
+      Role: desktopChrome
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_records_follow_up_tickets.ticket_history_partner_header_label$
+      Role: desktopChrome
+    - Type: wait_for
+      Strategy: xpath
+      Id: $PAGE.care_platform_participant_records_follow_up_tickets.ticket_history_subject_header_label$
+      Role: desktopChrome

--- a/tests/page_objects/care_platform_page.yaml
+++ b/tests/page_objects/care_platform_page.yaml
@@ -213,7 +213,7 @@ care_platform_participant_details:
   new_ticket_subject_by_name: //div[@tab-title='Follow-up Tickets']//div[@class='accordion-item-toggle']//div[contains(text(),'$AND_CLI_FOLLOW_UP_TICKET$')]
   new_ticket_date: (//div[@class='accordion-item']//div[contains(text(),'Automated test')]/preceding-sibling::div[contains(text(),'$AND_CLI_TODAYS_DATE$')])[last()]
   new_ticket_date_by_name: (//div[@class='accordion-item']//div[contains(text(),'$AND_CLI_FOLLOW_UP_TICKET$')]/preceding-sibling::div[contains(text(),'$AND_CLI_TODAYS_DATE$')])[last()]
-  records_button: //a//button[text()='Records']
+  records_button: //button[text()='Records']
   records_link: //a[contains(text(),'Records')]
 
 care_platform_participant_records:

--- a/tests/sets/set_non_physical_mobile_tests.yaml
+++ b/tests/sets/set_non_physical_mobile_tests.yaml
@@ -69,6 +69,7 @@ SetNonPhysicalMobileTest:
     - Case: TestProviderAttemptAnOnDemandCallToFacilitysDeviceThatIsMissedFacilityPane
     - Case: TestProviderCanClickAndViewFacilityFollowUpTicketsInformation
     - Case: TestProviderAttemptAnOnDemandCallToParticipantsDeviceThatIsMissed
+    - Case: TestProviderCanClickAndViewParticipantsFollowUpTicketsInformation
   # ES Provider Care Platform
     - Case: TestESProviderCarePlatformAnswerAndCompleteSession
     - Case: TestESProviderIDDSeeCallAppearInQueueAssignAndReviewDetails

--- a/tests/sets/set_provider_care_platform.yaml
+++ b/tests/sets/set_provider_care_platform.yaml
@@ -66,3 +66,4 @@ SetProvidersCarePlatformTests:
     - Case: TestProviderAttemptAnOnDemandCallToFacilitysDeviceThatIsMissedFacilityPane
     - Case: TestProviderCanClickAndViewFacilityFollowUpTicketsInformation
     - Case: TestProviderAttemptAnOnDemandCallToParticipantsDeviceThatIsMissed
+    - Case: TestProviderCanClickAndViewParticipantsFollowUpTicketsInformation


### PR DESCRIPTION
-Added tests
-Added sets

![image](https://github.com/neveralone-chs-org/TestRay/assets/118225389/47c190e8-b141-4bdc-b68c-d8304a909f75)
