### PR TITLE
fix: CXTB-784 admin on call tests

### DIFF
--- a/tests/cases/admin_on_call_care_platform/case_admin_on_call_care_platform_user_actions.yaml
+++ b/tests/cases/admin_on_call_care_platform/case_admin_on_call_care_platform_user_actions.yaml
@@ -186,6 +186,8 @@ TestAdminOnCallRefreshNurseFacilityDeviceForCalling:
       Strategy: xpath
       Id: $PAGE.providers_home_page.on_demand_calls$
       Role: desktopChrome
+    - Type: sleep
+      Time: 1
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.providers_call_handling_page.answer_call_button$

--- a/tests/cases/admin_on_call_care_platform/case_admin_on_call_staff_listing.yaml
+++ b/tests/cases/admin_on_call_care_platform/case_admin_on_call_staff_listing.yaml
@@ -162,7 +162,7 @@ TestAdminOnCallRefreshSessionForStaffMemberFromPane:
     Environment: Settings
     Vars:
       LOGOUT_OPTION: "Stay On Shift"
-      USER_FULLNAME: $AND_CLI_carepartner_user1_name$ $AND_CLI_carepartner_user1_lastname$
+      USER_FULLNAME: $AND_CLI_carepartner_user1_lastname$
       STAFF_ROLE: "Care Partner"
     Precases:
       - LoginNeverAloneHelper

--- a/tests/cases/helpers/case_helpers_care_platform_providers.yaml
+++ b/tests/cases/helpers/case_helpers_care_platform_providers.yaml
@@ -228,6 +228,8 @@ JoinMedicalTransfer:
     - Type: click
       Strategy: xpath
       Id: $PAGE.providers_home_page.last_medical_transfer_row$
+    - Type: sleep
+      Time: 1
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.providers_call_handling_page.answer_call_button$
@@ -1403,6 +1405,8 @@ MakeCallBetweenProviderAndEHP:
       Id: $PAGE.providers_home_page.on_demand_calls$
       Role: desktopChrome
   #Answer call
+    - Type: sleep
+      Time: 1
     - Type: wait_for
       Strategy: xpath
       Role: desktopChrome


### PR DESCRIPTION
![image](https://github.com/neveralone-chs-org/TestRay/assets/118279681/371830ba-cb8d-4004-a35f-ae7ea64fd9f8)
- add sleep to steps where the "no node" issue is faced
- fix for search bar