### PR TITLE
CXTB-786: fixes for seniors

### DIFF
--- a/lib/core/device.rb
+++ b/lib/core/device.rb
@@ -2376,6 +2376,7 @@ def provider_clean_hanged_call_or_session(action, main_case, main_case_id)
       wait_for_enabled_element("$PAGE.care_platform_home.first_call_of_queue$")
       @driver.find_element(:xpath, convert_value_pageobjects("$PAGE.care_platform_home.first_call_of_queue$")).click
       log_info("answer call")
+      sleep(2)
       wait_for_element_to_exist("$PAGE.care_platform_home.answer_call$")
       @driver.find_element(:xpath, convert_value_pageobjects("$PAGE.care_platform_home.answer_call$")).click
       

--- a/tests/cases/helpers/case_helpers_care_platform.yaml
+++ b/tests/cases/helpers/case_helpers_care_platform.yaml
@@ -624,6 +624,12 @@ AnswerCallAndRescheduleForOneHourLater:
       Role: desktopChrome
       Strategy: xpath
       Id: $PAGE.care_platform_home.first_call_of_queue$
+    - Type: sleep
+      Time: 2
+    - Type: wait_for
+      Role: desktopChrome
+      Strategy: xpath
+      Id: $PAGE.care_platform_home.answer_call$
     - Type: click
       Role: desktopChrome
       Strategy: xpath
@@ -781,6 +787,12 @@ AnswerPastCallAndRescheduleForOneHourLater:
       Role: desktopChrome
       Strategy: xpath
       Id: $PAGE.care_platform_home.first_call_of_queue$
+    - Type: sleep
+      Time: 2
+    - Type: wait_for
+      Role: desktopChrome
+      Strategy: xpath
+      Id: $PAGE.care_platform_home.answer_call$
     - Type: click
       Role: desktopChrome
       Strategy: xpath
@@ -1762,6 +1774,8 @@ CarePartnerCallSenior:
       Strategy: xpath
       Id: $PAGE.care_platform_participant.senior_complete_name$
     # Click on the Call Portal button.
+    - Type: sleep
+      Time: 1
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.care_platform_participant.call_portal_btn$
@@ -1769,6 +1783,8 @@ CarePartnerCallSenior:
       Strategy: xpath
       Id: $PAGE.care_platform_participant.call_portal_btn$
     # Click "Call Participant" button.
+    - Type: sleep
+      Time: 2
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.care_platform_call_portal.call_participant_btn$

--- a/tests/cases/helpers/case_helpers_care_platform_providers.yaml
+++ b/tests/cases/helpers/case_helpers_care_platform_providers.yaml
@@ -1123,15 +1123,20 @@ AnswerCallAsProvider:
     - Type: click
       Strategy: xpath
       Id: $PAGE.providers_home_page.call_based_on_participant_name$
+    - Type: sleep
+      Time: 2
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.providers_call_handling_page.answer_call_button$
     - Type: click
       Strategy: xpath
       Id: $PAGE.providers_call_handling_page.answer_call_button$
+    - Type: sleep
+      Time: 2
     - Type: wait_for
       Strategy: xpath
       Id: $PAGE.providers_call_handling_page.end_call_btn$
+      Time: 30
 
 AnswerOnDemandCallAsProvider:
   Roles:

--- a/tests/cases/seniors_app/case_seniors_app_account_statuses.yaml
+++ b/tests/cases/seniors_app/case_seniors_app_account_statuses.yaml
@@ -230,6 +230,8 @@ TestSeniorAppSuspendedAccountStatus:
   Environment: Settings
   Vars:
     LOGOUT_OPTION: "Yes Logout"
+  Precases:
+    - AdminOnCallRefreshParticipant
   Aftercases:
     - TerminateApp
     - AlternativeCarePartnerLogout

--- a/tests/cases/seniors_app/case_seniors_app_prompts.yaml
+++ b/tests/cases/seniors_app/case_seniors_app_prompts.yaml
@@ -628,6 +628,7 @@ TestSeniorStartingSoonNotificationWaitUntilCallSurveyIsCompleted:
   Environment: Settings
   Precases:
     - LoginNeverAloneHelper
+    - AdminOnCallRefreshParticipant
     - CarePartnerCleanCallQueueAndHangedCalls
     - SeniorCleanPrompts
     - ProviderNewCleaner
@@ -925,6 +926,7 @@ TestSeniorVerifyCallWillNotRedirectToHomePageAfter10MinutesWithoutAction:
   Environment: Settings
   Precases:
     - LoginNeverAloneHelper
+    - AdminOnCallRefreshParticipant
     - CarePartnerCleanCallQueueAndHangedCalls
     - SeniorCleanPrompts
   Aftercases:

--- a/tests/cases/seniors_app/case_seniors_app_schedule.yaml
+++ b/tests/cases/seniors_app/case_seniors_app_schedule.yaml
@@ -111,7 +111,7 @@ TestSeniorSchedulesPageNavigation:
       Value: SchedulesPageNavigationHelper
 
 # CXTB-39: Automatically Return to Full Schedule Page After Period of Inactivity
-TestSeniorAutomaticReturnAfterInactivty:
+TestSeniorAutomaticReturnAfterInactivity:
   Environment: Settings
   Precases:
     - LoginNeverAloneHelper

--- a/tests/sets/set_non_physical_mobile_tests.yaml
+++ b/tests/sets/set_non_physical_mobile_tests.yaml
@@ -104,7 +104,7 @@ SetNonPhysicalMobileTest:
     - Case: TestSeniorVerifyCallWillNotRedirectToHomePageAfter10MinutesWithoutAction
     - Case: TestSeniorVerifyFullScheduleDisplay
     - Case: TestSeniorSchedulesPageNavigation
-    - Case: TestSeniorAutomaticReturnAfterInactivty
+    - Case: TestSeniorAutomaticReturnAfterInactivity
     - Case: TestSeniorNoPromptsForCancelledAppointments
     - Case: TestSeniorFutureNonTelehealthEventWindowAccess
     - Case: TestSeniorFutureAppointmentCancelOrRescheduleButton

--- a/tests/sets/set_senior_never_alone_app.yaml
+++ b/tests/sets/set_senior_never_alone_app.yaml
@@ -17,10 +17,10 @@ SetSeniorNeverAloneAppTest:
     - Case: TestSeniorAppIgnoreCarePartnerCall
     - Case: TestSeniorAppIgnoreProviderCall
     - Case: TestSeniorStartingSoonNotificationWaitUntilCallSurveyIsCompleted
-    - Case: TestSeniorVerifyCallWillNotRedirectToHomePageAfter10MinutesWithoutAction
     - Case: TestSeniorVerifyFullScheduleDisplay
     - Case: TestSeniorSchedulesPageNavigation
-    - Case: TestSeniorAutomaticReturnAfterInactivty
+    - Case: TestSeniorAutomaticReturnAfterInactivity
+    - Case: TestSeniorVerifyCallWillNotRedirectToHomePageAfter10MinutesWithoutAction
     - Case: TestSeniorNoPromptsForCancelledAppointments
     - Case: TestSeniorFutureNonTelehealthEventWindowAccess
     - Case: TestSeniorFutureAppointmentCancelOrRescheduleButton


### PR DESCRIPTION
- add sleeps to avoid stale elements and no node id errors
- add existing helpers to as pre case on some test to upgrade data clean-up

![image](https://github.com/neveralone-chs-org/TestRay/assets/118279681/2fe2a28f-e83c-427b-9079-b1ba80b0157d)

NOTE: failed tests from screenshot are known issues such as:
- EMS
- Provider no longer saying "Dr." on senior prompts
- Wifi saying its not connected
- environment temporary issues where somehow credentials fail (possible deployments at the moment of test run)